### PR TITLE
Consolidate dependencies version numbers in maven properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,30 @@
         <url>https://github.com/yang-central/yangkit</url>
     </scm>
 
+    <properties>
+        <org.dom4j.dom4j.version>2.1.4</org.dom4j.dom4j.version>
+        <com.google.code.findbugs.jsr305.version>3.0.2</com.google.code.findbugs.jsr305.version>
+        <org.eclipse.jdt.org.eclipse.jdt.annotation.version>2.2.700</org.eclipse.jdt.org.eclipse.jdt.annotation.version>
+        <org.slf4j.slf4j-api.version>2.0.6</org.slf4j.slf4j-api.version>
+        <org.slf4j.slf4j-reload4j.version>2.0.6</org.slf4j.slf4j-reload4j.version>
+        <org.apache.commons.commons-lang3.version>3.12.0</org.apache.commons.commons-lang3.version>
+        <junit.junit.version>4.13.2</junit.junit.version>
+        <com.github.albfernandez.juniversalchardet.version>2.4.0</com.github.albfernandez.juniversalchardet.version>
+        <org.antlr.antlr4-runtime.version>4.11.1</org.antlr.antlr4-runtime.version>
+        <com.google.code.gson.version>2.10.1</com.google.code.gson.version>
+        <jaxen.jaxen.version>2.0.0</jaxen.jaxen.version>
+
+        <io.github.yang-central.yangkit.yangkit-common.version>1.1.1</io.github.yang-central.yangkit.yangkit-common.version>
+        <io.github.yang-central.yangkit.yangkit-common-utils.version>1.0.1</io.github.yang-central.yangkit.yangkit-common-utils.version>
+
+        <io.github.yang-central.yangkit.yangkit-model-api.version>${project.version}</io.github.yang-central.yangkit.yangkit-model-api.version>
+        <io.github.yang-central.yangkit.yangkit-model-impl.version>${project.version}</io.github.yang-central.yangkit.yangkit-model-impl.version>
+        <io.github.yang-central.yangkit.yangkit-data-api.version>${project.version}</io.github.yang-central.yangkit.yangkit-data-api.version>
+        <io.github.yang-central.yangkit.yangkit-data-impl.version>${project.version}</io.github.yang-central.yangkit.yangkit-data-impl.version>
+        <io.github.yang-central.yangkit.yangkit-xpath-api.version>${project.version}</io.github.yang-central.yangkit.yangkit-xpath-api.version>
+        <io.github.yang-central.yangkit.yangkit-xpath-impl.version>${project.version}</io.github.yang-central.yangkit.yangkit-xpath-impl.version>
+    </properties>
+
     <profiles>
         <profile>
             <id>release</id>

--- a/yangkit-data-api/pom.xml
+++ b/yangkit-data-api/pom.xml
@@ -16,6 +16,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/yangkit-data-api/pom.xml
+++ b/yangkit-data-api/pom.xml
@@ -27,27 +27,27 @@
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-model-api</artifactId>
-            <version>1.3.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-model-api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
+            <version>${com.google.code.findbugs.jsr305.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-common</artifactId>
-            <version>1.1.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-common.version}</version>
         </dependency>
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.1</version>
+            <version>${org.dom4j.dom4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>org.eclipse.jdt.annotation</artifactId>
-            <version>2.2.100</version>
+            <version>${org.eclipse.jdt.org.eclipse.jdt.annotation.version}</version>
         </dependency>
     </dependencies>
 

--- a/yangkit-data-impl/pom.xml
+++ b/yangkit-data-impl/pom.xml
@@ -14,17 +14,17 @@
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-data-api</artifactId>
-            <version>1.3.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-data-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${org.slf4j.slf4j-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <artifactId>slf4j-reload4j</artifactId>
+            <version>${org.slf4j.slf4j-reload4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/yangkit-model-api/pom.xml
+++ b/yangkit-model-api/pom.xml
@@ -16,6 +16,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/yangkit-model-api/pom.xml
+++ b/yangkit-model-api/pom.xml
@@ -28,24 +28,24 @@
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-common</artifactId>
-            <version>1.1.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-common.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-xpath-api</artifactId>
-            <version>1.3.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-xpath-api.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>${org.apache.commons.commons-lang3.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/yangkit-model-impl/pom.xml
+++ b/yangkit-model-impl/pom.xml
@@ -46,33 +46,33 @@
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-model-api</artifactId>
-            <version>1.3.0</version>
+            <version>${io.github.yang-central.yangkit.yangkit-model-api.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-xpath-impl</artifactId>
-            <version>1.3.0</version>
+            <version>${io.github.yang-central.yangkit.yangkit-xpath-impl.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>${org.apache.commons.commons-lang3.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.albfernandez</groupId>
             <artifactId>juniversalchardet</artifactId>
-            <version>2.4.0</version>
+            <version>${com.github.albfernandez.juniversalchardet.version}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.7.2</version>
+            <version>${org.antlr.antlr4-runtime.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/yangkit-model-impl/pom.xml
+++ b/yangkit-model-impl/pom.xml
@@ -16,6 +16,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/yangkit-parser/pom.xml
+++ b/yangkit-parser/pom.xml
@@ -16,6 +16,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/yangkit-parser/pom.xml
+++ b/yangkit-parser/pom.xml
@@ -28,33 +28,33 @@
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-common</artifactId>
-            <version>1.1.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-common.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-common-utils</artifactId>
-            <version>1.0.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-common-utils.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-model-api</artifactId>
-            <version>1.3.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-model-api.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-model-impl</artifactId>
-            <version>1.3.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-model-impl.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>${com.google.code.gson.version}</version>
         </dependency>
     </dependencies>
 

--- a/yangkit-xpath-api/pom.xml
+++ b/yangkit-xpath-api/pom.xml
@@ -16,6 +16,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/yangkit-xpath-api/pom.xml
+++ b/yangkit-xpath-api/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>1.2.0</version>
+            <version>${jaxen.jaxen.version}</version>
         </dependency>
 
     </dependencies>

--- a/yangkit-xpath-impl/pom.xml
+++ b/yangkit-xpath-impl/pom.xml
@@ -27,18 +27,18 @@
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-xpath-api</artifactId>
-            <version>1.3.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-xpath-api.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-model-api</artifactId>
-            <version>1.3.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-model-api.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.yang-central.yangkit</groupId>
             <artifactId>yangkit-data-api</artifactId>
-            <version>1.3.1</version>
+            <version>${io.github.yang-central.yangkit.yangkit-data-api.version}</version>
         </dependency>
     </dependencies>
 

--- a/yangkit-xpath-impl/pom.xml
+++ b/yangkit-xpath-impl/pom.xml
@@ -16,6 +16,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>


### PR DESCRIPTION
- Consolidate dependencies version numbers in maven properties.
- Update outdated versions to get the latest security fixes.
- Set the maven compiler plugin version to suppress maven warnings 