### PR TITLE
Use StringBuilder instead of StringBuffer

### DIFF
--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/base/ErrorCode.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/base/ErrorCode.java
@@ -160,7 +160,7 @@ public enum ErrorCode {
    }
 
    public String toString(String[] args) {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append(this.formatFieldName(args));
       if (null != this.reference) {
          sb.append(" reference:");

--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/base/Position.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/base/Position.java
@@ -26,7 +26,7 @@ public class Position {
    }
 
    public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append("source:");
       sb.append(this.source);
       sb.append(" ");

--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/model/api/stmt/ModelException.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/model/api/stmt/ModelException.java
@@ -36,7 +36,6 @@ public class ModelException extends Exception {
    }
 
    public String toString() {
-      StringBuffer sb = new StringBuffer();
-      return sb.toString();
+      return "";
    }
 }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/codec/BitsStringValueCodecImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/codec/BitsStringValueCodecImpl.java
@@ -36,7 +36,7 @@ public class BitsStringValueCodecImpl extends StringValueCodecImpl<List<String>>
       if (!bool) {
          throw new YangCodecException(ErrorCode.INVALID_VALUE.getFieldName());
       } else {
-         StringBuffer sb = new StringBuffer();
+         StringBuilder sb = new StringBuilder();
          Iterator iterator = output.iterator();
 
          while(iterator.hasNext()) {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/schema/SchemaPathImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/schema/SchemaPathImpl.java
@@ -53,7 +53,7 @@ public abstract class SchemaPathImpl implements SchemaPath {
    }
 
    public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       if (this.isAbsolute()) {
          sb.append("/");
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YangStatementImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YangStatementImpl.java
@@ -889,7 +889,7 @@ public abstract class YangStatementImpl implements YangStatement {
    }
 
    public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       QName keyword = this.getYangKeyword();
       if (keyword.getNamespace().equals(Yang.NAMESPACE.getUri())) {
          sb.append(keyword.getLocalName());

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/LineColumnLocation.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/LineColumnLocation.java
@@ -22,7 +22,7 @@ public class LineColumnLocation implements Location<String> {
    }
 
    public String getLocation() {
-      StringBuffer sb = new StringBuffer(" line:");
+      StringBuilder sb = new StringBuilder(" line:");
       sb.append(this.line);
       sb.append(" column:");
       sb.append(this.column);

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/ModuleSupportCapability.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/ModuleSupportCapability.java
@@ -73,7 +73,7 @@ public class ModuleSupportCapability extends Capability {
    }
 
    public String toString() {
-      StringBuffer sb = new StringBuffer(this.getUri().toString());
+      StringBuilder sb = new StringBuilder(this.getUri().toString());
       sb.append("?");
       sb.append("module=");
       sb.append(this.module);

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangParser.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangParser.java
@@ -112,7 +112,7 @@ public class YangParser {
          boolean isInMultiComments = false;
          boolean isInDQuotes = false;
          boolean isInSQuotes = false;
-         StringBuffer sb = new StringBuffer();
+         StringBuilder sb = new StringBuilder();
 
          for(int i = 0; i < size; ++i) {
             char c = str.charAt(i);
@@ -276,7 +276,7 @@ public class YangParser {
       if (null == value) {
          return null;
       } else {
-         StringBuffer sb = new StringBuffer();
+         StringBuilder sb = new StringBuilder();
          int length = value.length();
 
          for(int i = 0; i < length; ++i) {
@@ -328,7 +328,7 @@ public class YangParser {
       if (null == value) {
          return null;
       } else {
-         StringBuffer sb = new StringBuffer();
+         StringBuilder sb = new StringBuilder();
          int valueBeginColumn = env.getCurColumn();
          String[] lineValues = value.split("\n");
          int size = lineValues.length;
@@ -445,7 +445,7 @@ public class YangParser {
             if (0 == values.size()) {
                return null;
             } else {
-               StringBuffer sb = new StringBuffer();
+               StringBuilder sb = new StringBuilder();
 
                for(int i = 0; i < values.size(); ++i) {
                   str = values.get(i);

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangParserException.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangParserException.java
@@ -28,7 +28,7 @@ public class YangParserException extends Exception {
    }
 
    public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append("@" + this.position.toString());
       switch (this.severity) {
          case ERROR:

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/writter/YangWriter.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/writter/YangWriter.java
@@ -17,7 +17,7 @@ public class YangWriter {
          return null;
       } else {
 
-         StringBuffer sb = new StringBuffer();
+         StringBuilder sb = new StringBuilder();
          sb.append("\"");
          int length = value.length();
 
@@ -45,7 +45,7 @@ public class YangWriter {
    }
 
    private static String buildLinePrefix(int size) {
-      StringBuffer sBuffer = new StringBuffer();
+      StringBuilder sBuffer = new StringBuilder();
 
       for(int i = 0; i < size; ++i) {
          sBuffer.append(" ");
@@ -173,7 +173,7 @@ public class YangWriter {
    }
 
    public static String toYangString(YangElement element, YangFormatter format, String curIndentation) {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       if (null == element) {
          return null;
       } else {

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangLocationPathImpl.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangLocationPathImpl.java
@@ -40,7 +40,7 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
    }
 
    public String getText() {
-      StringBuffer buf = new StringBuffer();
+      StringBuilder buf = new StringBuilder();
       Iterator stepIter = this.getSteps().iterator();
 
       while(stepIter.hasNext()) {
@@ -228,7 +228,7 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
    }
 
    public String toString() {
-      StringBuffer buf = new StringBuffer();
+      StringBuilder buf = new StringBuilder();
       Iterator stepIter = this.getSteps().iterator();
 
       while(stepIter.hasNext()) {

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangNameStep.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangNameStep.java
@@ -10,7 +10,7 @@ public class YangNameStep extends DefaultNameStep {
    }
 
    public String getText() {
-      StringBuffer buf = new StringBuffer(64);
+      StringBuilder buf = new StringBuilder(64);
       if (this.getAxis() != 1) {
          buf.append(this.getAxisName()).append("::");
       }


### PR DESCRIPTION
StringBuffer is designed to be thread-safe with synchronized methods. That means it's generally slower than StrinBuilder. This commit replaces the StringBuffer uses with StringBuilder in places which thread-saftey is not a concern.