### PR TITLE
Code harding and improvements

### DIFF
--- a/yangkit-data-api/src/main/java/org/yangcentral/yangkit/data/api/operation/DataChangeNotifier.java
+++ b/yangkit-data-api/src/main/java/org/yangcentral/yangkit/data/api/operation/DataChangeNotifier.java
@@ -17,7 +17,7 @@ public class DataChangeNotifier {
 
    public void addListener(DataChangeListener listener) {
       if (null == this.listeners) {
-         this.listeners = new ArrayList();
+         this.listeners = new ArrayList<>();
          this.listeners.add(listener);
       } else {
          Iterator var2 = this.listeners.iterator();

--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/base/YangContext.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/base/YangContext.java
@@ -21,7 +21,7 @@ public class YangContext {
    private Module curModule;
    private Grouping curGrouping;
    private Namespace curNamespace;
-   private List<YangContext> mergedContexts = new ArrayList();
+   private List<YangContext> mergedContexts = new ArrayList<>();
    private YangStatement self;
    private Map<String, SchemaNode> SchemaNodeIdentifierCache = new ConcurrentHashMap();
    private Map<String, Grouping> groupingIdentifierCache = new ConcurrentHashMap();

--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/model/api/schema/ModuleSet.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/model/api/schema/ModuleSet.java
@@ -11,8 +11,8 @@ import java.util.List;
  */
 public class ModuleSet {
    private String name;
-   private List<YangModuleDescription> modules = new ArrayList();
-   private List<YangModuleDescription> importOnlyModules = new ArrayList();
+   private List<YangModuleDescription> modules = new ArrayList<>();
+   private List<YangModuleDescription> importOnlyModules = new ArrayList<>();
 
    public String getName() {
       return this.name;

--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/model/api/schema/YangModuleDescription.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/model/api/schema/YangModuleDescription.java
@@ -11,9 +11,9 @@ import java.util.List;
  */
 public class YangModuleDescription {
    private ModuleId moduleId;
-   private List<ModuleId> subModules = new ArrayList();
-   private List<String> features = new ArrayList();
-   private List<String> deviations = new ArrayList();
+   private List<ModuleId> subModules = new ArrayList<>();
+   private List<String> features = new ArrayList<>();
+   private List<String> deviations = new ArrayList<>();
 
    public YangModuleDescription(ModuleId moduleId) {
       this.moduleId = moduleId;

--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/model/api/schema/YangSchema.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/model/api/schema/YangSchema.java
@@ -11,7 +11,7 @@ import java.util.List;
  */
 public class YangSchema {
    private String name;
-   private List<ModuleSet> moduleSets = new ArrayList();
+   private List<ModuleSet> moduleSets = new ArrayList<>();
 
    public void setName(String name) {
       this.name = name;

--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/register/YangStatementParserPolicy.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/register/YangStatementParserPolicy.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class YangStatementParserPolicy {
    private QName keyword;
    private Class<? extends YangStatement> clazz;
-   private List<BuildPhase> phases = new ArrayList();
+   private List<BuildPhase> phases = new ArrayList<>();
 
    public YangStatementParserPolicy(QName keyword, Class<? extends YangStatement> clazz, List<BuildPhase> phases) {
       this.keyword = keyword;

--- a/yangkit-model-api/src/main/java/org/yangcentral/yangkit/register/YangUnknownParserPolicy.java
+++ b/yangkit-model-api/src/main/java/org/yangcentral/yangkit/register/YangUnknownParserPolicy.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class YangUnknownParserPolicy extends YangStatementParserPolicy {
-   private List<YangParentStatementInfo> parentStatements = new ArrayList();
+   private List<YangParentStatementInfo> parentStatements = new ArrayList<>();
    private YangStatementDef statementDef;
 
    public YangUnknownParserPolicy(QName keyword, Class<? extends YangUnknown> clazz, List<BuildPhase> phases) {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/codec/BitsStringValueCodecImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/codec/BitsStringValueCodecImpl.java
@@ -6,13 +6,12 @@ import org.yangcentral.yangkit.model.api.codec.YangCodecException;
 import org.yangcentral.yangkit.model.api.restriction.Restriction;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class BitsStringValueCodecImpl extends StringValueCodecImpl<List<String>> implements BitsStringValueCodec {
    public List<String> deserialize(Restriction<List<String>> restriction, String input) throws YangCodecException {
       String[] splitStr = input.split(" ");
-      List<String> ret = new ArrayList();
+      List<String> ret = new ArrayList<>();
       int length = splitStr.length;
 
       for(int i = 0; i < length; ++i) {
@@ -37,10 +36,7 @@ public class BitsStringValueCodecImpl extends StringValueCodecImpl<List<String>>
          throw new YangCodecException(ErrorCode.INVALID_VALUE.getFieldName());
       } else {
          StringBuilder sb = new StringBuilder();
-         Iterator iterator = output.iterator();
-
-         while(iterator.hasNext()) {
-            String str = (String)iterator.next();
+         for (String str : output) {
             sb.append(str);
             sb.append(" ");
          }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/BitsImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/BitsImpl.java
@@ -12,7 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
-   private List<Bit> bits = new ArrayList();
+   private List<Bit> bits = new ArrayList<>();
 
    public BitsImpl(YangContext context, Typedef derived) {
       super(context, derived);
@@ -43,7 +43,7 @@ public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
          Long highest = null;
 
          for(int i = 0; i < index; ++i) {
-            Bit bit = (Bit)this.bits.get(i);
+            Bit bit = this.bits.get(i);
             Long cur = null;
             if (bit.getPosition() != null) {
                cur = bit.getPosition().getValue();
@@ -69,7 +69,7 @@ public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
    }
 
    private Long getBitActualPosition(int index) {
-      Bit bit = (Bit)this.bits.get(index);
+      Bit bit = this.bits.get(index);
       if (bit.getPosition() != null) {
          return bit.getPosition().getValue();
       } else if (index == 0) {
@@ -89,7 +89,7 @@ public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
          int pos = -1;
 
          for(int i = 0; i < this.bits.size(); ++i) {
-            Bit bit = (Bit)this.bits.get(i);
+            Bit bit = this.bits.get(i);
             if (bit.getArgStr().equals(bitName)) {
                pos = i;
                break;
@@ -101,7 +101,7 @@ public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
    }
 
    public boolean addBit(Bit bit) {
-      Iterator bitIterator = this.bits.iterator();
+      Iterator<Bit> bitIterator = this.bits.iterator();
 
       Bit orignalBit;
       do {
@@ -109,14 +109,14 @@ public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
             return this.bits.add(bit);
          }
 
-         orignalBit = (Bit)bitIterator.next();
+         orignalBit = bitIterator.next();
       } while(!orignalBit.getArgStr().equals(bit.getArgStr()));
 
       return false;
    }
 
    public Bit getBit(String name) {
-      Iterator bitIterator = this.bits.iterator();
+      Iterator<Bit> bitIterator = this.bits.iterator();
 
       Bit bit;
       do {
@@ -124,7 +124,7 @@ public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
             return null;
          }
 
-         bit = (Bit)bitIterator.next();
+         bit = bitIterator.next();
       } while(!name.equals(bit.getArgStr()));
 
       return bit;
@@ -161,7 +161,7 @@ public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
          Bits derivedBits = (Bits)this.getDerived().getType().getRestriction();
          return derivedBits.getEffectiveBits();
       } else {
-         return new ArrayList();
+         return new ArrayList<>();
       }
    }
 
@@ -176,11 +176,11 @@ public class BitsImpl extends RestrictionImpl<List<String>> implements Bits {
             return false;
          } else {
             for(int i = 0; i < thisBits.size(); ++i) {
-               Bit bit = (Bit)thisBits.get(i);
+               Bit bit = thisBits.get(i);
                Bit anotherMatchedBit = null;
 
                for(int j = 0; j < anotherBits.size(); ++j) {
-                  Bit anotherBit = (Bit)anotherBits.get(j);
+                  Bit anotherBit = anotherBits.get(j);
                   if (bit.getArgStr().equals(anotherBit.getArgStr())) {
                      anotherMatchedBit = anotherBit;
                      break;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/Decimal64Impl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/Decimal64Impl.java
@@ -72,16 +72,14 @@ public class Decimal64Impl extends RestrictionImpl<BigDecimal> implements Decima
          if (this.getDerived() != null && !this.range.isSubSet(((Decimal64)this.getDerived().getType().getRestriction()).getEffectiveRange())) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(range,ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getSeverity(),
                     ErrorTag.BAD_ELEMENT,ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getFieldName()));
-            return validatorResultBuilder.build();
-         } else {
-            return validatorResultBuilder.build();
          }
+         return validatorResultBuilder.build();
       }
    }
 
    public boolean evaluated(BigDecimal value) {
       if (this.getRange() != null) {
-         Iterator iterator = this.getRange().getSections().iterator();
+         Iterator<Section> iterator = this.getRange().getSections().iterator();
 
          Section section;
          do {
@@ -89,7 +87,7 @@ public class Decimal64Impl extends RestrictionImpl<BigDecimal> implements Decima
                return false;
             }
 
-            section = (Section)iterator.next();
+            section = iterator.next();
          } while(value.compareTo((BigDecimal)section.getMin()) < 0 || value.compareTo((BigDecimal)section.getMax()) > 0);
 
          return true;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/EnumerationImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/EnumerationImpl.java
@@ -12,7 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class EnumerationImpl extends RestrictionImpl<String> implements Enumeration {
-   private List<YangEnum> enums = new ArrayList();
+   private List<YangEnum> enums = new ArrayList<>();
 
    public EnumerationImpl(YangContext context, Typedef derived) {
       super(context, derived);
@@ -102,7 +102,7 @@ public class EnumerationImpl extends RestrictionImpl<String> implements Enumerat
    }
 
    public boolean addEnum(YangEnum yangEnum) {
-      Iterator enumIterator = this.enums.iterator();
+      Iterator<YangEnum> enumIterator = this.enums.iterator();
 
       YangEnum originalEnum;
       do {
@@ -110,7 +110,7 @@ public class EnumerationImpl extends RestrictionImpl<String> implements Enumerat
             return this.enums.add(yangEnum);
          }
 
-         originalEnum = (YangEnum)enumIterator.next();
+         originalEnum = enumIterator.next();
       } while(!originalEnum.getArgStr().equals(yangEnum.getArgStr()));
 
       return false;
@@ -138,7 +138,7 @@ public class EnumerationImpl extends RestrictionImpl<String> implements Enumerat
          Enumeration derivedEnumeration = (Enumeration)this.getDerived().getType().getRestriction();
          return derivedEnumeration.getEffectiveEnums();
       } else {
-         return new ArrayList();
+         return new ArrayList<>();
       }
    }
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/IdentityRefImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/IdentityRefImpl.java
@@ -15,7 +15,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class IdentityRefImpl extends RestrictionImpl<QName> implements IdentityRef {
-   private List<Base> bases = new ArrayList();
+   private List<Base> bases = new ArrayList<>();
 
    public IdentityRefImpl(YangContext context, Typedef derived) {
       super(context, derived);
@@ -81,7 +81,7 @@ public class IdentityRefImpl extends RestrictionImpl<QName> implements IdentityR
          IdentityRef anotherResriction = (IdentityRef)this.getDerived().getType().getRestriction();
          return anotherResriction.getEffectiveBases();
       } else {
-         return new ArrayList();
+         return new ArrayList<>();
       }
    }
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/UnionImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/UnionImpl.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class UnionImpl extends RestrictionImpl<Object> implements Union {
-   private List<Type> types = new ArrayList();
+   private List<Type> types = new ArrayList<>();
 
    public UnionImpl(YangContext context, Typedef derived) {
       super(context, derived);
@@ -40,7 +40,7 @@ public class UnionImpl extends RestrictionImpl<Object> implements Union {
          UnionImpl derived = (UnionImpl)this.getDerived().getType().getRestriction();
          return derived.getActualTypes();
       } else {
-         return new ArrayList();
+         return new ArrayList<>();
       }
    }
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/YangStringImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/restriction/YangStringImpl.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class YangStringImpl extends RestrictionImpl<String> implements YangString {
-   private List<Pattern> patterns = new ArrayList();
+   private List<Pattern> patterns = new ArrayList<>();
    private Length length;
 
    public YangStringImpl(YangContext context, Typedef derived) {
@@ -140,7 +140,7 @@ public class YangStringImpl extends RestrictionImpl<String> implements YangStrin
    }
 
    public List<Pattern> getEffectivePatterns() {
-      List<Pattern> effectivePatterns = new ArrayList();
+      List<Pattern> effectivePatterns = new ArrayList<>();
       if (this.patterns.size() > 0) {
          effectivePatterns.addAll(this.patterns);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/schema/AbsoluteSchemaPath.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/schema/AbsoluteSchemaPath.java
@@ -41,7 +41,7 @@ public class AbsoluteSchemaPath extends SchemaPathImpl implements SchemaPath.Abs
       } else if (!path.contains(this)) {
          return null;
       } else {
-         List<QName> steps = new ArrayList();
+         List<QName> steps = new ArrayList<>();
          int thisSize = this.getPath().size();
          int descendentSie = path.getPath().size();
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/schema/SchemaPathImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/schema/SchemaPathImpl.java
@@ -7,12 +7,10 @@ import org.yangcentral.yangkit.model.api.schema.ModuleId;
 import org.yangcentral.yangkit.model.api.schema.SchemaPath;
 import org.yangcentral.yangkit.model.api.schema.YangSchemaContext;
 import org.yangcentral.yangkit.model.api.stmt.Import;
-import org.yangcentral.yangkit.model.api.stmt.MainModule;
 import org.yangcentral.yangkit.model.api.stmt.ModelException;
 import org.yangcentral.yangkit.model.api.stmt.Module;
 import org.yangcentral.yangkit.model.api.stmt.SchemaNode;
 import org.yangcentral.yangkit.model.api.stmt.SchemaNodeContainer;
-import org.yangcentral.yangkit.model.api.stmt.SubModule;
 import org.yangcentral.yangkit.model.api.stmt.VirtualSchemaNode;
 import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 
@@ -25,16 +23,12 @@ import java.util.Optional;
 import java.util.Stack;
 
 public abstract class SchemaPathImpl implements SchemaPath {
-   private Stack<QName> steps = new Stack();
+   private Stack<QName> steps = new Stack<>();
 
    public SchemaPathImpl(List<QName> steps) {
-      Iterator iterator = steps.iterator();
-
-      while(iterator.hasNext()) {
-         QName step = (QName)iterator.next();
+      for (QName step : steps) {
          this.steps.push(step);
       }
-
    }
 
    public SchemaPathImpl() {
@@ -45,11 +39,11 @@ public abstract class SchemaPathImpl implements SchemaPath {
    }
 
    public QName getLast() {
-      return (QName)this.steps.peek();
+      return this.steps.peek();
    }
 
    public List<QName> getPath() {
-      return new ArrayList(this.steps);
+      return new ArrayList<>(this.steps);
    }
 
    public String toString() {
@@ -61,8 +55,8 @@ public abstract class SchemaPathImpl implements SchemaPath {
       boolean first = true;
 
       QName step;
-      for(Iterator iterator = this.steps.iterator(); iterator.hasNext(); sb.append(step.getQualifiedName())) {
-         step = (QName)iterator.next();
+      for(Iterator<QName> iterator = this.steps.iterator(); iterator.hasNext(); sb.append(step.getQualifiedName())) {
+         step = iterator.next();
          if (!first) {
             sb.append("/");
          } else {
@@ -74,13 +68,10 @@ public abstract class SchemaPathImpl implements SchemaPath {
    }
 
    public static SchemaPath from(SchemaNodeContainer contextNode, YangStatement yangStatement,String path) throws ModelException {
-      boolean isAbsolute = false;
-      if (path.startsWith("/")) {
-         isAbsolute = true;
-      }
+      boolean isAbsolute = path.startsWith("/");
 
       String[] steps = path.split("/");
-      List<QName> stepList = new ArrayList();
+      List<QName> stepList = new ArrayList<>();
       int length = steps.length;
 
       for(int i = 0; i < length; ++i) {
@@ -117,7 +108,7 @@ public abstract class SchemaPathImpl implements SchemaPath {
                   throw new ModelException(Severity.ERROR, (isAbsolute ? module : (YangStatement)contextNode), "can't find the module which prefix:" + prefix + " points to");
                }
 
-               Optional<Module> moduleOp = module.getContext().getSchemaContext().getModule((ModuleId)moduleIdOp.get());
+               Optional<Module> moduleOp = module.getContext().getSchemaContext().getModule(moduleIdOp.get());
                if (!moduleIdOp.isPresent()) {
                   throw new ModelException(Severity.ERROR, (isAbsolute ? module : (YangStatement)contextNode), "can't find the module which prefix:" + prefix + " points to");
                }
@@ -139,13 +130,11 @@ public abstract class SchemaPathImpl implements SchemaPath {
    }
 
    private List<SchemaNode> match(List<SchemaNode> candidate, QName qName) {
-      List<SchemaNode> matched = new ArrayList();
-      Iterator iterator = candidate.iterator();
+      List<SchemaNode> matched = new ArrayList<>();
 
-      while(iterator.hasNext()) {
-         SchemaNode schemaNode = (SchemaNode)iterator.next();
+      for (SchemaNode schemaNode : candidate) {
          if (schemaNode instanceof VirtualSchemaNode) {
-            VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode)schemaNode;
+            VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode) schemaNode;
             matched.addAll(this.match(virtualSchemaNode.getSchemaNodeChildren(), qName));
          } else if (schemaNode.getIdentifier().equals(qName)) {
             matched.add(schemaNode);
@@ -157,7 +146,7 @@ public abstract class SchemaPathImpl implements SchemaPath {
 
    public SchemaNode getSchemaNode(YangSchemaContext schemaContext) {
       List<QName> pathElements = this.getPath();
-      List<SchemaNode> candidate = new ArrayList();
+      List<SchemaNode> candidate = new ArrayList<>();
       if (this.isAbsolute()) {
          candidate.addAll(schemaContext.getSchemaNodeChildren());
       } else {
@@ -166,22 +155,18 @@ public abstract class SchemaPathImpl implements SchemaPath {
       }
 
       List<SchemaNode> matched = null;
-      Iterator iterator = pathElements.iterator();
 
-      while(iterator.hasNext()) {
-         QName pathElement = (QName)iterator.next();
+      for (QName pathElement : pathElements) {
          matched = this.match(candidate, pathElement);
          if (matched.size() == 0) {
             return null;
          }
 
          candidate.clear();
-         Iterator matchedIt = matched.iterator();
 
-         while(matchedIt.hasNext()) {
-            SchemaNode matchedNode = (SchemaNode)matchedIt.next();
+         for (SchemaNode matchedNode : matched) {
             if (matchedNode instanceof SchemaNodeContainer) {
-               candidate.addAll(((SchemaNodeContainer)matchedNode).getSchemaNodeChildren());
+               candidate.addAll(((SchemaNodeContainer) matchedNode).getSchemaNodeChildren());
             }
          }
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/schema/YangSchemaContextImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/schema/YangSchemaContextImpl.java
@@ -20,10 +20,10 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class YangSchemaContextImpl implements YangSchemaContext {
-   private List<Module> modules = new ArrayList();
-   private List<Module> importOnlyModules = new ArrayList();
-   private Map<String, List<Module>> moduleMap = new ConcurrentHashMap();
-   private Map<String, List<YangElement>> parseResult = new ConcurrentHashMap();
+   private List<Module> modules = new ArrayList<>();
+   private List<Module> importOnlyModules = new ArrayList<>();
+   private Map<String, List<Module>> moduleMap = new ConcurrentHashMap<>();
+   private Map<String, List<YangElement>> parseResult = new ConcurrentHashMap<>();
    private YangSchema schema;
 
    private ValidatorResult validatorResult;
@@ -97,11 +97,11 @@ public class YangSchemaContextImpl implements YangSchemaContext {
    }
 
    public List<Module> getModule(URI namespace) {
-      List<Module> candiate = new ArrayList();
+      List<Module> candiate = new ArrayList<>();
       Iterator<List<Module>> valueIt = this.moduleMap.values().iterator();
 
       while(true) {
-         List modules;
+         List<Module> modules;
          do {
             if (!valueIt.hasNext()) {
                return candiate;
@@ -110,10 +110,7 @@ public class YangSchemaContextImpl implements YangSchemaContext {
             modules = valueIt.next();
          } while(null == modules);
 
-         Iterator iterator = modules.iterator();
-
-         while(iterator.hasNext()) {
-            Module module = (Module)iterator.next();
+         for (Module module : modules) {
             if (module.getMainModule() != null) {
                URI uri = module.getMainModule().getNamespace().getUri();
                if (uri.equals(namespace)) {
@@ -138,7 +135,7 @@ public class YangSchemaContextImpl implements YangSchemaContext {
       if (filterModules != null && filterModules.size() != 0) {
          filterModules.add(module);
       } else {
-         filterModules = new ArrayList();
+         filterModules = new ArrayList<>();
          filterModules.add(module);
          this.moduleMap.put(module.getArgStr(), filterModules);
       }
@@ -149,7 +146,7 @@ public class YangSchemaContextImpl implements YangSchemaContext {
    public void addImportOnlyModule(Module module) {
       List<Module> filterModules = this.moduleMap.get(module.getArgStr());
       if (filterModules != null && filterModules.size() != 0) {
-         Iterator iterator = filterModules.iterator();
+         Iterator<Module> iterator = filterModules.iterator();
 
          Module candidate;
          do {
@@ -159,11 +156,11 @@ public class YangSchemaContextImpl implements YangSchemaContext {
                return;
             }
 
-            candidate = (Module)iterator.next();
+            candidate = iterator.next();
          } while(!candidate.getModuleId().equals(module.getModuleId()));
 
       } else {
-         filterModules = new ArrayList();
+         filterModules = new ArrayList<>();
          filterModules.add(module);
          this.moduleMap.put(module.getArgStr(), filterModules);
          this.importOnlyModules.add(module);
@@ -171,7 +168,7 @@ public class YangSchemaContextImpl implements YangSchemaContext {
    }
 
    public boolean isImportOnly(Module module) {
-      Iterator iterator = this.importOnlyModules.iterator();
+      Iterator<Module> iterator = this.importOnlyModules.iterator();
 
       Module importOnlyModule;
       do {
@@ -179,7 +176,7 @@ public class YangSchemaContextImpl implements YangSchemaContext {
             return false;
          }
 
-         importOnlyModule = (Module)iterator.next();
+         importOnlyModule = iterator.next();
       } while(importOnlyModule != module);
 
       return true;
@@ -189,12 +186,10 @@ public class YangSchemaContextImpl implements YangSchemaContext {
       if (!this.moduleMap.containsKey(moduleId.getModuleName())) {
          return null;
       } else {
-         List<Module> filterModules = (List)this.moduleMap.get(moduleId.getModuleName());
+         List<Module> filterModules = this.moduleMap.get(moduleId.getModuleName());
          Module matchedModule = null;
-         Iterator iterator = filterModules.iterator();
 
-         while(iterator.hasNext()) {
-            Module module = (Module)iterator.next();
+         for (Module module : filterModules) {
             if (module.getModuleId().equals(moduleId)) {
                matchedModule = module;
                break;
@@ -224,7 +219,7 @@ public class YangSchemaContextImpl implements YangSchemaContext {
    }
 
    private void buildDependencies(){
-      List<Module> modules = new ArrayList();
+      List<Module> modules = new ArrayList<>();
       modules.addAll(this.getModules());
       modules.addAll(this.getImportOnlyModules());
       for(Module module:modules){
@@ -274,7 +269,7 @@ public class YangSchemaContextImpl implements YangSchemaContext {
     */
    public ValidatorResult validate() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      List<Module> modules = new ArrayList();
+      List<Module> modules = new ArrayList<>();
       modules.addAll(this.getModules());
       modules.addAll(this.getImportOnlyModules());
       buildDependencies();
@@ -326,10 +321,8 @@ public class YangSchemaContextImpl implements YangSchemaContext {
 
    public ValidatorResult addSchemaNodeChildren(List<SchemaNode> schemaNodes) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator iterator = schemaNodes.iterator();
 
-      while(iterator.hasNext()) {
-         SchemaNode schemaNode = (SchemaNode)iterator.next();
+      for (SchemaNode schemaNode : schemaNodes) {
          validatorResultBuilder.merge(this.addSchemaNodeChild(schemaNode));
       }
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ActionContainerImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ActionContainerImpl.java
@@ -14,7 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 
 class ActionContainerImpl implements ActionContainer {
-   private List<Action> actions = new ArrayList();
+   private List<Action> actions = new ArrayList<>();
    private YangContext yangContext;
 
    public YangContext getYangContext() {
@@ -26,7 +26,7 @@ class ActionContainerImpl implements ActionContainer {
    }
 
    public Action getAction(String actionName) {
-      Iterator iterator = this.actions.iterator();
+      Iterator<Action> iterator = this.actions.iterator();
 
       Action action;
       do {
@@ -34,7 +34,7 @@ class ActionContainerImpl implements ActionContainer {
             return null;
          }
 
-         action = (Action)iterator.next();
+         action = iterator.next();
       } while(!action.getArgStr().equals(actionName));
 
       return action;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ActionImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ActionImpl.java
@@ -1,19 +1,13 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
-import org.yangcentral.yangkit.base.BuildPhase;
 import org.yangcentral.yangkit.base.ErrorCode;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
-import org.yangcentral.yangkit.base.YangContext;
 import org.yangcentral.yangkit.common.api.QName;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
-import org.yangcentral.yangkit.model.api.schema.SchemaTreeType;
 import org.yangcentral.yangkit.model.api.stmt.*;
 import org.yangcentral.yangkit.util.ModelUtil;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 
 public class ActionImpl extends OperationImpl implements Action {
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/AnyDataImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/AnyDataImpl.java
@@ -59,7 +59,7 @@ public class AnyDataImpl extends DataNodeImpl implements Anydata {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.mandatory != null) {
          statements.add(this.mandatory);
       } else {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/AnyxmlImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/AnyxmlImpl.java
@@ -57,7 +57,7 @@ public class AnyxmlImpl extends DataNodeImpl implements Anyxml {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.mandatory != null) {
          statements.add(this.mandatory);
       } else {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ArgumentImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ArgumentImpl.java
@@ -49,7 +49,7 @@ public class ArgumentImpl extends YangBuiltInStatementImpl implements Argument {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.yinElement != null) {
          statements.add(this.yinElement);
       } else {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/AugmentImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/AugmentImpl.java
@@ -157,12 +157,10 @@ public class AugmentImpl extends DataDefinitionImpl implements Augment {
    protected ValidatorResult initSelf() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.initSelf());
       List<YangElement> subElements = this.getSubElements();
-      Iterator elementIterator = subElements.iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : subElements) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
             switch (builtinKeyword) {
                case CONTAINER:
@@ -174,15 +172,15 @@ public class AugmentImpl extends DataDefinitionImpl implements Augment {
                case CHOICE:
                case CASE:
                case USES:
-                  DataDefinition newDataDefinition = (DataDefinition)builtinStatement;
+                  DataDefinition newDataDefinition = (DataDefinition) builtinStatement;
                   validatorResultBuilder.merge(this.addDataDefChild(newDataDefinition));
                   break;
                case ACTION:
-                  Action newAction = (Action)builtinStatement;
+                  Action newAction = (Action) builtinStatement;
                   validatorResultBuilder.merge(this.addAction(newAction));
                   break;
                case NOTIFICATION:
-                  Notification newNotification = (Notification)builtinStatement;
+                  Notification newNotification = (Notification) builtinStatement;
                   validatorResultBuilder.merge(this.addNotification(newNotification));
             }
          }
@@ -193,37 +191,23 @@ public class AugmentImpl extends DataDefinitionImpl implements Augment {
 
    protected ValidatorResult buildSelf(BuildPhase phase) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.buildSelf(phase));
-      Iterator iterator;
-      SchemaNode child;
       switch (phase) {
          case SCHEMA_BUILD:
-            List<DataDefinition> dataDefChildren = this.getDataDefChildren();
-            Iterator schemaChildrenIt = dataDefChildren.iterator();
-
-            while(schemaChildrenIt.hasNext()) {
-               DataDefinition dataDefinition = (DataDefinition)schemaChildrenIt.next();
-               validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
+            for (DataDefinition dataDefinition : getDataDefChildren()) {
+               validatorResultBuilder.merge(addSchemaNodeChild(dataDefinition));
             }
 
-            schemaChildrenIt = this.getActions().iterator();
-
-            while(schemaChildrenIt.hasNext()) {
-               Action action = (Action)schemaChildrenIt.next();
-               validatorResultBuilder.merge(this.addSchemaNodeChild(action));
+            for (Action action : getActions()) {
+               validatorResultBuilder.merge(addSchemaNodeChild(action));
             }
 
-            schemaChildrenIt = this.getNotifications().iterator();
-
-            while(schemaChildrenIt.hasNext()) {
-               Notification notification = (Notification)schemaChildrenIt.next();
+            for (Notification notification : getNotifications()) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(notification));
             }
 
             return validatorResultBuilder.build();
          case SCHEMA_EXPAND:
-            iterator = this.getSchemaNodeChildren().iterator();
-            while(iterator.hasNext()) {
-               child = (SchemaNode)iterator.next();
+            for (SchemaNode child: getSchemaNodeChildren()) {
                if (child instanceof DataDefinition) {
                   if (!(this.target instanceof DataDefContainer)) {
                      validatorResultBuilder.addRecord(
@@ -267,10 +251,7 @@ public class AugmentImpl extends DataDefinitionImpl implements Augment {
 
             return validatorResultBuilder.build();
          case SCHEMA_TREE:
-            iterator = this.getSchemaNodeChildren().iterator();
-
-            while(iterator.hasNext()) {
-               child = (SchemaNode)iterator.next();
+            for (SchemaNode child: getSchemaNodeChildren()) {
                if (child instanceof Case && ((Case)child).isShortCase()) {
                   validatorResultBuilder.merge(child.build(phase));
                }
@@ -353,7 +334,7 @@ public class AugmentImpl extends DataDefinitionImpl implements Augment {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(getEffectiveSchemaNodeChildren());
       statements.addAll(super.getEffectiveSubStatements());
       return statements;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/BelongsToImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/BelongsToImpl.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 public class BelongsToImpl extends YangBuiltInStatementImpl implements BelongsTo {
    private Prefix prefix;
-   private List<MainModule> mainModules = new ArrayList();
+   private List<MainModule> mainModules = new ArrayList<>();
 
    public BelongsToImpl(String argStr) {
       super(argStr);
@@ -43,16 +43,14 @@ public class BelongsToImpl extends YangBuiltInStatementImpl implements BelongsTo
 
       List<Module> modules = this.getContext().getSchemaContext().getModule(moduleName);
       if (modules != null) {
-         Iterator moduleIterator = modules.iterator();
 
-         while(moduleIterator.hasNext()) {
-            Module module = (Module)moduleIterator.next();
+         for (Module module : modules) {
             if (module instanceof SubModule) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(this,
-                       ErrorCode.WRONG_TYPE_DEPENDECE_MODULE.getFieldName()
-                               + " It MUST be module, but get a submodule."));
+                   ErrorCode.WRONG_TYPE_DEPENDECE_MODULE.getFieldName()
+                       + " It MUST be module, but get a submodule."));
             } else {
-               this.mainModules.add((MainModule)module);
+               this.mainModules.add((MainModule) module);
             }
          }
       }
@@ -100,7 +98,7 @@ public class BelongsToImpl extends YangBuiltInStatementImpl implements BelongsTo
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.prefix != null) {
          statements.add(this.prefix);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/CaseImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/CaseImpl.java
@@ -101,12 +101,10 @@ public class CaseImpl extends DataDefinitionImpl implements Case {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       validatorResultBuilder.merge(super.initSelf());
       List<YangElement> subElements = this.getSubElements();
-      Iterator subElementIt = subElements.iterator();
 
-      while(subElementIt.hasNext()) {
-         YangElement subElement = (YangElement)subElementIt.next();
+      for (YangElement subElement : subElements) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
             switch (builtinKeyword) {
                case CONTAINER:
@@ -117,7 +115,7 @@ public class CaseImpl extends DataDefinitionImpl implements Case {
                case ANYXML:
                case CHOICE:
                case USES:
-                  DataDefinition newDataDefinition = (DataDefinition)builtinStatement;
+                  DataDefinition newDataDefinition = (DataDefinition) builtinStatement;
                   validatorResultBuilder.merge(this.dataDefContainer.addDataDefChild(newDataDefinition));
             }
          }
@@ -184,10 +182,7 @@ public class CaseImpl extends DataDefinitionImpl implements Case {
       validatorResultBuilder.merge(super.buildSelf(phase));
       switch (phase) {
          case SCHEMA_BUILD:
-            Iterator iterator = this.getDataDefChildren().iterator();
-
-            while(iterator.hasNext()) {
-               DataDefinition dataDefinition = (DataDefinition)iterator.next();
+            for (DataDefinition dataDefinition : this.getDataDefChildren()) {
                if (dataDefinition.evaluateFeatures()) {
                   validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
                }
@@ -216,7 +211,7 @@ public class CaseImpl extends DataDefinitionImpl implements Case {
       return schemaNodeContainer.getEffectiveSchemaNodeChildren(ignoreNamespace);
    }
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(getEffectiveSchemaNodeChildren());
       statements.addAll(super.getEffectiveSubStatements());
       return statements;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ChoiceImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ChoiceImpl.java
@@ -17,10 +17,10 @@ import java.util.List;
 public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
    private Default aDefault;
    private Case defaultCase;
-   private List<Case> cases = new ArrayList();
+   private List<Case> cases = new ArrayList<>();
    private Mandatory mandatory;
    private SchemaNodeContainerImpl schemaNodeContainer = new SchemaNodeContainerImpl(this);
-   private List<DataDefinition> dataDefinitions = new ArrayList();
+   private List<DataDefinition> dataDefinitions = new ArrayList<>();
    private QName identifier;
 
    public ChoiceImpl(String argStr) {
@@ -205,12 +205,10 @@ public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       validatorResultBuilder.merge(super.initSelf());
       List<YangElement> subElements = this.getSubElements();
-      Iterator iterator = subElements.iterator();
 
-      while(iterator.hasNext()) {
-         YangElement subElement = (YangElement)iterator.next();
+      for (YangElement subElement : subElements) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
             switch (builtinKeyword) {
                case CASE:
@@ -221,7 +219,7 @@ public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
                case LEAF:
                case LEAFLIST:
                case LIST:
-                  validatorResultBuilder.merge(this.addDataDefChild((DataDefinition)builtinStatement));
+                  validatorResultBuilder.merge(this.addDataDefChild((DataDefinition) builtinStatement));
             }
          }
       }
@@ -282,8 +280,6 @@ public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
       ValidatorResultBuilder validatorResultBuilder;
       validatorResultBuilder = new ValidatorResultBuilder();
       validatorResultBuilder.merge(super.buildSelf(phase));
-      Iterator iterator;
-      Case c;
       label44:
       switch (phase) {
          case GRAMMAR:
@@ -297,24 +293,21 @@ public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
                           ErrorCode.DEFAULT_CASE_IS_OPTIONAL.getFieldName()));
                }
             }
-            iterator = this.cases.iterator();
-
-            while(iterator.hasNext()) {
-               c = (Case)iterator.next();
+            for (Case c: this.cases) {
                if (c.evaluateFeatures() && c.isShortCase()) {
                   validatorResultBuilder.merge(c.build(phase));
                }
             }
             break;
          case SCHEMA_BUILD:
-            iterator = this.cases.iterator();
+            Iterator<Case> iterator = this.cases.iterator();
 
             while(true) {
                if (!iterator.hasNext()) {
                   break label44;
                }
 
-               c = (Case)iterator.next();
+               Case c = iterator.next();
                if (c.evaluateFeatures()) {
                   this.addSchemaNodeChild(c);
                   if (c.isShortCase()) {
@@ -323,10 +316,7 @@ public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
                }
             }
          case SCHEMA_TREE:
-            iterator = this.cases.iterator();
-
-            while(iterator.hasNext()) {
-               c = (Case)iterator.next();
+            for (Case c: this.cases) {
                if (c.evaluateFeatures() && c.isShortCase()) {
                   validatorResultBuilder.merge(c.build(phase));
                }
@@ -355,7 +345,7 @@ public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
    }
 
    public DataDefinition getDataDefChild(String name) {
-      Iterator iterator = this.dataDefinitions.iterator();
+      Iterator<DataDefinition> iterator = this.dataDefinitions.iterator();
 
       DataDefinition dataDefinition;
       do {
@@ -363,7 +353,7 @@ public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
             return null;
          }
 
-         dataDefinition = (DataDefinition)iterator.next();
+         dataDefinition = iterator.next();
       } while(!dataDefinition.getArgStr().equals(name));
 
       return dataDefinition;
@@ -403,7 +393,7 @@ public class ChoiceImpl extends SchemaDataNodeImpl implements Choice {
       return schemaNodeContainer.getEffectiveSchemaNodeChildren(ignoreNamespace);
    }
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.mandatory != null) {
          statements.add(this.mandatory);
       } else {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ConfigImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ConfigImpl.java
@@ -14,7 +14,7 @@ public class ConfigImpl extends YangSimpleStatementImpl implements Config {
    }
 
    public boolean isConfig() {
-      return Boolean.valueOf(this.getArgStr());
+      return Boolean.parseBoolean(this.getArgStr());
    }
 
    public QName getYangKeyword() {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ContainerDataNodeImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ContainerDataNodeImpl.java
@@ -21,14 +21,13 @@ import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 public abstract class ContainerDataNodeImpl extends DataNodeImpl implements ContainerDataNode {
    private ActionContainerImpl actionContainer = new ActionContainerImpl();
    private DataDefContainerImpl dataDefContainer = new DataDefContainerImpl();
    private GroupingDefContainerImpl groupingDefContainer = new GroupingDefContainerImpl();
-   private List<MountPoint> mountPoints = new ArrayList();
+   private List<MountPoint> mountPoints = new ArrayList<>();
    private NotificationContainerImpl notificationContainer = new NotificationContainerImpl();
    private TypedefContainerImpl typedefContainer = new TypedefContainerImpl();
    private SchemaNodeContainerImpl schemaNodeContainer = new SchemaNodeContainerImpl(this);
@@ -163,21 +162,17 @@ public abstract class ContainerDataNodeImpl extends DataNodeImpl implements Cont
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       validatorResultBuilder.merge(super.initSelf());
 
-      List<YangElement> subElements = this.getSubElements();
-      Iterator iterator = subElements.iterator();
-
-      while(iterator.hasNext()) {
-         YangElement subElement = (YangElement)iterator.next();
+      for (YangElement subElement : getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
             switch (builtinKeyword) {
                case TYPEDEF:
-                  Typedef newTypedef = (Typedef)builtinStatement;
+                  Typedef newTypedef = (Typedef) builtinStatement;
                   validatorResultBuilder.merge(this.typedefContainer.addTypedef(newTypedef));
                   break;
                case GROUPING:
-                  Grouping newGrouping = (Grouping)builtinStatement;
+                  Grouping newGrouping = (Grouping) builtinStatement;
                   validatorResultBuilder.merge(this.groupingDefContainer.addGrouping(newGrouping));
                   break;
                case CONTAINER:
@@ -188,15 +183,15 @@ public abstract class ContainerDataNodeImpl extends DataNodeImpl implements Cont
                case ANYXML:
                case CHOICE:
                case USES:
-                  DataDefinition newDataDefinition = (DataDefinition)builtinStatement;
+                  DataDefinition newDataDefinition = (DataDefinition) builtinStatement;
                   validatorResultBuilder.merge(this.dataDefContainer.addDataDefChild(newDataDefinition));
                   break;
                case ACTION:
-                  Action newAction = (Action)builtinStatement;
+                  Action newAction = (Action) builtinStatement;
                   validatorResultBuilder.merge(this.actionContainer.addAction(newAction));
                   break;
                case NOTIFICATION:
-                  Notification newNotification = (Notification)builtinStatement;
+                  Notification newNotification = (Notification) builtinStatement;
                   validatorResultBuilder.merge(this.notificationContainer.addNotification(newNotification));
             }
          }
@@ -246,24 +241,13 @@ public abstract class ContainerDataNodeImpl extends DataNodeImpl implements Cont
       validatorResultBuilder.merge(super.buildSelf(phase));
       switch (phase) {
          case SCHEMA_BUILD:
-            Iterator iterator = this.getDataDefChildren().iterator();
-
-            while(iterator.hasNext()) {
-               DataDefinition dataDefinition = (DataDefinition)iterator.next();
+            for (DataDefinition dataDefinition: getDataDefChildren()) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
             }
-
-            iterator = this.getActions().iterator();
-
-            while(iterator.hasNext()) {
-               Action action = (Action)iterator.next();
+            for (Action action: getActions()) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(action));
             }
-
-            iterator = this.getNotifications().iterator();
-
-            while(iterator.hasNext()) {
-               Notification notification = (Notification)iterator.next();
+            for (Notification notification: getNotifications()) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(notification));
             }
          default:
@@ -275,7 +259,7 @@ public abstract class ContainerDataNodeImpl extends DataNodeImpl implements Cont
       return schemaNodeContainer.getEffectiveSchemaNodeChildren(ignoreNamespace);
    }
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(getEffectiveSchemaNodeChildren());
       statements.addAll(this.groupingDefContainer.getGroupings());
       statements.addAll(this.typedefContainer.getTypedefs());

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ContainerImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ContainerImpl.java
@@ -53,7 +53,7 @@ public class ContainerImpl extends ContainerDataNodeImpl implements Container {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.presence != null) {
          statements.add(this.presence);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DataDefContainerImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DataDefContainerImpl.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class DataDefContainerImpl implements DataDefContainer {
-   private List<DataDefinition> dataDefs = new ArrayList();
+   private List<DataDefinition> dataDefs = new ArrayList<>();
    private YangContext yangContext;
 
    public YangContext getYangContext() {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DataDefinitionImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DataDefinitionImpl.java
@@ -17,7 +17,6 @@ import org.yangcentral.yangkit.xpath.impl.YangXPathContext;
 import org.yangcentral.yangkit.xpath.impl.YangXPathValidator;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public abstract class DataDefinitionImpl extends SchemaNodeImpl implements DataDefinition {
@@ -128,11 +127,9 @@ public abstract class DataDefinitionImpl extends SchemaNodeImpl implements DataD
       }
 
       matched = this.getSubStatement(YangBuiltinKeyword.IFFEATURE.getQName());
-      Iterator statementIterator = matched.iterator();
 
-      while(statementIterator.hasNext()) {
-         YangStatement statement = (YangStatement)statementIterator.next();
-         IfFeature ifFeature = (IfFeature)statement;
+      for (YangStatement statement : matched) {
+         IfFeature ifFeature = (IfFeature) statement;
          validatorResultBuilder.merge(this.ifFeatureSupport.addIfFeature(ifFeature));
       }
 
@@ -146,7 +143,7 @@ public abstract class DataDefinitionImpl extends SchemaNodeImpl implements DataD
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.when != null) {
          statements.add(this.when);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DataNodeImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DataNodeImpl.java
@@ -10,7 +10,6 @@ import org.yangcentral.yangkit.model.api.stmt.Must;
 import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public abstract class DataNodeImpl extends SchemaDataNodeImpl implements DataNode {
@@ -92,11 +91,8 @@ public abstract class DataNodeImpl extends SchemaDataNodeImpl implements DataNod
 
       List<YangStatement> matched = this.getSubStatement(YangBuiltinKeyword.MUST.getQName());
       if (matched.size() != 0) {
-         Iterator iterator = matched.iterator();
-
-         while(iterator.hasNext()) {
-            YangStatement statement = (YangStatement)iterator.next();
-            validatorResultBuilder.merge(this.mustSupport.addMust((Must)statement));
+         for (YangStatement statement : matched) {
+            validatorResultBuilder.merge(this.mustSupport.addMust((Must) statement));
          }
       }
 
@@ -119,7 +115,7 @@ public abstract class DataNodeImpl extends SchemaDataNodeImpl implements DataNod
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(this.mustSupport.getMusts());
       statements.addAll(super.getEffectiveSubStatements());
       return statements;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DefaultYangUnknown.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DefaultYangUnknown.java
@@ -62,11 +62,11 @@ public class DefaultYangUnknown extends YangStatementImpl implements YangUnknown
          if (!optionalModule.isPresent()) {
             return null;
          } else {
-            Optional<Module> impModuleOp = schemaContext.getModule((ModuleId)optionalModule.get());
+            Optional<Module> impModuleOp = schemaContext.getModule(optionalModule.get());
             if (!impModuleOp.isPresent()) {
                return null;
             } else {
-               Module impModule = (Module)impModuleOp.get();
+               Module impModule = impModuleOp.get();
                return impModule.getExtension(extensionName);
             }
          }
@@ -139,13 +139,11 @@ public class DefaultYangUnknown extends YangStatementImpl implements YangUnknown
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
-      Iterator var2 = this.getSubElements().iterator();
+      List<YangStatement> statements = new ArrayList<>();
 
-      while(var2.hasNext()) {
-         YangElement element = (YangElement)var2.next();
+      for (YangElement element : this.getSubElements()) {
          if (element instanceof YangStatement) {
-            statements.add((YangStatement)element);
+            statements.add((YangStatement) element);
          }
       }
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DeviateImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DeviateImpl.java
@@ -2,7 +2,6 @@ package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.*;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.Choice;
@@ -33,20 +32,19 @@ import org.yangcentral.yangkit.util.ModelUtil;
 import org.yangcentral.yangkit.xpath.impl.XPathUtil;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
    private SchemaNode target;
    private DeviateType deviateType;
    private Config config;
-   private List<Default> defaults = new ArrayList();
+   private List<Default> defaults = new ArrayList<>();
    private Mandatory mandatory;
    private MaxElements maxElements;
    private MinElements minElements;
    private MustSupportImpl mustSupport = new MustSupportImpl();
    private Type type;
-   private List<Unique> uniques = new ArrayList();
+   private List<Unique> uniques = new ArrayList<>();
    private Units units;
 
    public DeviateImpl(String argStr) {
@@ -83,51 +81,48 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
          return validatorResultBuilder.build();
       }
 
-      Iterator elementIterator = this.getSubElements().iterator();
-
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(((YangBuiltinStatement)subElement).getYangKeyword());
+            YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(((YangBuiltinStatement) subElement).getYangKeyword());
             switch (builtinKeyword) {
                case CONFIG:
-                  this.config = (Config)subElement;
+                  this.config = (Config) subElement;
                   break;
                case MUST:
-                  validatorResultBuilder.merge(this.addMust((Must)subElement));
+                  validatorResultBuilder.merge(this.addMust((Must) subElement));
                   break;
                case DEFAULT:
-                  Default oldDefault = (Default) ModelUtil.checkConflict((Default)subElement, this.defaults);
+                  Default oldDefault = ModelUtil.checkConflict((Default) subElement, this.defaults);
                   if (oldDefault != null) {
-                     validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(oldDefault, (Default)subElement));
-                     ((Default)subElement).setErrorStatement(true);
+                     validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(oldDefault, (Default) subElement));
+                     ((Default) subElement).setErrorStatement(true);
                   } else {
-                     this.defaults.add((Default)subElement);
+                     this.defaults.add((Default) subElement);
                   }
                   break;
                case MANDATORY:
-                  this.mandatory = (Mandatory)subElement;
+                  this.mandatory = (Mandatory) subElement;
                   break;
                case MAXELEMENTS:
-                  this.maxElements = (MaxElements)subElement;
+                  this.maxElements = (MaxElements) subElement;
                   break;
                case MINELEMENTS:
-                  this.minElements = (MinElements)subElement;
+                  this.minElements = (MinElements) subElement;
                   break;
                case TYPE:
-                  this.type = (Type)subElement;
+                  this.type = (Type) subElement;
                   break;
                case UNIQUE:
-                  Unique oldUnique = (Unique)ModelUtil.checkConflict((Unique)subElement, this.uniques);
+                  Unique oldUnique = ModelUtil.checkConflict((Unique) subElement, this.uniques);
                   if (oldUnique != null) {
-                     validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(oldUnique, (Unique)subElement));
-                     ((Unique)subElement).setErrorStatement(true);
+                     validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(oldUnique, (Unique) subElement));
+                     ((Unique) subElement).setErrorStatement(true);
                   } else {
-                     this.uniques.add((Unique)subElement);
+                     this.uniques.add((Unique) subElement);
                   }
                   break;
                case UNITS:
-                  this.units = (Units)subElement;
+                  this.units = (Units) subElement;
             }
          }
       }
@@ -167,24 +162,22 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                  ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
       } else {
          MustSupport mustSupport = (MustSupport)this.target;
-         Iterator mustIterator = this.getMusts().iterator();
 
-         while(mustIterator.hasNext()) {
-            Must must = (Must)mustIterator.next();
+         for (Must must : this.getMusts()) {
             SchemaNode schemaNode;
             switch (this.deviateType) {
                case ADD: {
                   YangStatement matchedStatement = mustSupport.getMust(must.getArgStr());
                   if (matchedStatement != null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(must,
-                             ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=must"})));
+                         ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=must"})));
                   } else {
                      Must orig = mustSupport.getMust(must.getArgStr());
-                     if( orig != null){
+                     if (orig != null) {
                         mustSupport.removeMust(must.getArgStr());
                      }
                      validatorResultBuilder.merge(mustSupport.addMust(must));
-                     schemaNode = (SchemaNode)mustSupport;
+                     schemaNode = (SchemaNode) mustSupport;
                      schemaNode.setDeviated(true);
                   }
                   break;
@@ -194,23 +187,23 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                   YangStatement matchedStatement = mustSupport.getMust(must.getArgStr());
                   if (matchedStatement == null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(must,
-                             ErrorCode.PROPERTY_NOT_MATCH.toString(new String[]{"name=must"})));
+                         ErrorCode.PROPERTY_NOT_MATCH.toString(new String[]{"name=must"})));
                   } else {
                      mustSupport.removeMust(must.getArgStr());
-                     schemaNode = (SchemaNode)mustSupport;
+                     schemaNode = (SchemaNode) mustSupport;
                      schemaNode.setDeviated(true);
                   }
                   break;
                }
 
-               case REPLACE:{
+               case REPLACE: {
                   YangStatement matchedStatement = mustSupport.getMust(must.getArgStr());
                   if (matchedStatement == null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(must,
-                             ErrorCode.PROPERTY_NOT_MATCH.toString(new String[]{"name=must"})));
+                         ErrorCode.PROPERTY_NOT_MATCH.toString(new String[]{"name=must"})));
                   } else {
                      mustSupport.updateMust(must);
-                     schemaNode = (SchemaNode)mustSupport;
+                     schemaNode = (SchemaNode) mustSupport;
                      schemaNode.setDeviated(true);
                   }
                   break;
@@ -226,7 +219,6 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
    private ValidatorResult deviateLeafDefault() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       Leaf leaf = (Leaf)this.target;
-      ValidatorRecordBuilder validatorRecordBuilder;
       if (this.defaults.size() > 1) {
          validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(1),
                  ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
@@ -291,10 +283,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(0),
                        ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=default"}) ));
             } else {
-               bool = choice.setDefault((Default)this.defaults.get(0));
+               bool = choice.setDefault(this.defaults.get(0));
                if (!bool) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(0),
-                          ErrorCode.MISSING_CASE.toString(new String[]{"name=" + ((Default)this.defaults.get(0)).getArgStr()})));
+                          ErrorCode.MISSING_CASE.toString(new String[]{"name=" + (this.defaults.get(0)).getArgStr()})));
                } else {
                   choice.setDeviated(true);
                }
@@ -319,10 +311,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(0),
                        ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=default"}) ));
             } else {
-               bool = choice.setDefault((Default)this.defaults.get(0));
+               bool = choice.setDefault(this.defaults.get(0));
                if (!bool) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(0),
-                          ErrorCode.MISSING_CASE.toString(new String[]{"name=" + ((Default)this.defaults.get(0)).getArgStr()})));
+                          ErrorCode.MISSING_CASE.toString(new String[]{"name=" + (this.defaults.get(0)).getArgStr()})));
                } else {
                   choice.setDeviated(true);
                }
@@ -335,16 +327,14 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
    private ValidatorResult deviateLeafListDefault() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       LeafList leafList = (LeafList)this.target;
-      Iterator defaultIterator = this.defaults.iterator();
 
-      while(defaultIterator.hasNext()) {
-         Default defl = (Default)defaultIterator.next();
+      for (Default defl : this.defaults) {
          Default orig = leafList.getDefault(defl.getArgStr());
          switch (this.deviateType) {
-            case ADD:{
-               if ( orig != null) {
+            case ADD: {
+               if (orig != null) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(defl,
-                          ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=default"})));
+                      ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=default"})));
                } else {
                   validatorResultBuilder.merge(leafList.addDefault(defl));
                   leafList.setDeviated(true);
@@ -352,10 +342,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                break;
             }
 
-            case DELETE:{
+            case DELETE: {
                if (orig == null) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(defl,
-                          ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=default"})));
+                      ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=default"})));
                } else {
                   leafList.removeDefault(defl.getArgStr());
                   leafList.setDeviated(true);
@@ -363,10 +353,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                break;
             }
 
-            case REPLACE:{
+            case REPLACE: {
                if (orig == null) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(defl,
-                          ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=default"})));
+                      ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=default"})));
                } else {
                   validatorResultBuilder.merge(leafList.updateDefault(defl));
                   leafList.setDeviated(true);
@@ -556,16 +546,14 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
          return validatorResultBuilder.build();
       } else {
          YangList list = (YangList)this.target;
-         Iterator uniqueIterator = this.uniques.iterator();
 
-         while(uniqueIterator.hasNext()) {
-            Unique unique = (Unique)uniqueIterator.next();
+         for (Unique unique : this.uniques) {
             Unique orig = list.getUnique(unique.getArgStr());
             switch (this.deviateType) {
-               case ADD:{
+               case ADD: {
                   if (orig != null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(unique,
-                             ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=unique"})));
+                         ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=unique"})));
                   } else {
                      validatorResultBuilder.merge(list.addUnique(unique));
                      list.setDeviated(true);
@@ -573,10 +561,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                   break;
                }
 
-               case DELETE:{
+               case DELETE: {
                   if (orig == null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(unique,
-                             ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=unique"})));
+                         ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=unique"})));
                   } else {
                      list.removeUnique(unique.getArgStr());
                      list.setDeviated(true);
@@ -584,10 +572,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                   break;
                }
 
-               case REPLACE:{
+               case REPLACE: {
                   if (orig == null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(unique,
-                             ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=unique"})));
+                         ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=unique"})));
                   } else {
                      validatorResultBuilder.merge(list.updateUnique(unique));
                      list.setDeviated(true);
@@ -688,28 +676,26 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
 
    private ValidatorResult deviateUnknown() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator unknownIterator = this.getUnknowns().iterator();
-      while(unknownIterator.hasNext()) {
-         YangUnknown yangUnknown = (YangUnknown)unknownIterator.next();
+      for (YangUnknown yangUnknown : this.getUnknowns()) {
          boolean isMultiInstance = true;
          YangSpecification yangSpecification = this.target.getContext().getYangSpecification();
          YangStatementDef yangStatementDef = yangSpecification.getStatementDef(this.target.getYangKeyword());
          Cardinality cardinality = yangStatementDef.getSubStatementCardinality(yangUnknown.getYangKeyword());
-         if(cardinality != null){
-            if(cardinality.getMaxElements() <=1){
+         if (cardinality != null) {
+            if (cardinality.getMaxElements() <= 1) {
                isMultiInstance = false;
             }
          }
-         if(!isMultiInstance){
+         if (!isMultiInstance) {
             List<YangUnknown> matched = this.target.getUnknowns(yangUnknown.getYangKeyword());
             switch (this.deviateType) {
-               case ADD:{
-                  if(matched != null && !matched.isEmpty()){
+               case ADD: {
+                  if (matched != null && !matched.isEmpty()) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(yangUnknown,
-                             ErrorCode.PROPERTY_EXIST.toString(new String[]{"name="+ yangUnknown.getYangKeyword().getQualifiedName()})));
+                         ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=" + yangUnknown.getYangKeyword().getQualifiedName()})));
                   } else {
                      List<YangUnknown> targetUnknowns = this.target.getUnknowns(yangUnknown.getYangKeyword());
-                     for(YangUnknown targetUnknown:targetUnknowns){
+                     for (YangUnknown targetUnknown : targetUnknowns) {
                         this.target.getUnknowns().remove(targetUnknown);
                      }
                      this.target.getUnknowns().add(yangUnknown);
@@ -717,14 +703,14 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                   }
                   break;
                }
-               case DELETE:{
-                  if(matched == null || matched.isEmpty()){
+               case DELETE: {
+                  if (matched == null || matched.isEmpty()) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(yangUnknown,
-                             ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name="+ yangUnknown.getYangKeyword().getQualifiedName()})));
+                         ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=" + yangUnknown.getYangKeyword().getQualifiedName()})));
                   } else {
-                     if(!matched.get(0).getArgStr().equals(yangUnknown.getArgStr())){
+                     if (!matched.get(0).getArgStr().equals(yangUnknown.getArgStr())) {
                         validatorResultBuilder.addRecord(ModelUtil.reportError(yangUnknown,
-                                ErrorCode.PROPERTY_NOT_MATCH.toString(new String[]{"name="+ yangUnknown.getYangKeyword().getQualifiedName()})));
+                            ErrorCode.PROPERTY_NOT_MATCH.toString(new String[]{"name=" + yangUnknown.getYangKeyword().getQualifiedName()})));
                      } else {
                         this.target.getUnknowns().remove(matched.get(0));
                         this.target.setDeviated(true);
@@ -734,10 +720,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                   break;
                }
 
-               case REPLACE:{
-                  if(matched == null || matched.isEmpty()){
+               case REPLACE: {
+                  if (matched == null || matched.isEmpty()) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(yangUnknown,
-                             ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name="+ yangUnknown.getYangKeyword().getQualifiedName()})));
+                         ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=" + yangUnknown.getYangKeyword().getQualifiedName()})));
                   } else {
                      this.target.getUnknowns().remove(matched.get(0));
                      this.target.getUnknowns().add(yangUnknown);
@@ -748,15 +734,15 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
             }
 
          } else {
-            YangUnknown orig =  this.target.getUnknown(yangUnknown.getYangKeyword(),yangUnknown.getArgStr());
+            YangUnknown orig = this.target.getUnknown(yangUnknown.getYangKeyword(), yangUnknown.getArgStr());
             switch (this.deviateType) {
-               case ADD:{
-                  if(orig != null){
+               case ADD: {
+                  if (orig != null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(yangUnknown,
-                             ErrorCode.PROPERTY_EXIST.toString(new String[]{"name="+ yangUnknown.getYangKeyword().getQualifiedName()})));
+                         ErrorCode.PROPERTY_EXIST.toString(new String[]{"name=" + yangUnknown.getYangKeyword().getQualifiedName()})));
                   } else {
-                     YangUnknown targetUnknown = this.target.getUnknown(yangUnknown.getYangKeyword(),yangUnknown.getArgStr());
-                     if(null != targetUnknown){
+                     YangUnknown targetUnknown = this.target.getUnknown(yangUnknown.getYangKeyword(), yangUnknown.getArgStr());
+                     if (null != targetUnknown) {
                         this.target.getUnknowns().remove(targetUnknown);
                      }
                      this.target.getUnknowns().add(yangUnknown);
@@ -764,10 +750,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                   }
                   break;
                }
-               case DELETE:{
-                  if(orig == null){
+               case DELETE: {
+                  if (orig == null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(yangUnknown,
-                             ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name="+ yangUnknown.getYangKeyword().getQualifiedName()})));
+                         ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=" + yangUnknown.getYangKeyword().getQualifiedName()})));
                   } else {
                      this.target.getUnknowns().remove(orig);
                      this.target.setDeviated(true);
@@ -775,10 +761,10 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
                   break;
                }
 
-               case REPLACE:{
-                  if(orig == null){
+               case REPLACE: {
+                  if (orig == null) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(yangUnknown,
-                             ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name="+ yangUnknown.getYangKeyword().getQualifiedName()})));
+                         ErrorCode.PROPERTY_NOT_EXIST.toString(new String[]{"name=" + yangUnknown.getYangKeyword().getQualifiedName()})));
                   } else {
                      this.target.getUnknowns().remove(orig);
                      this.target.getUnknowns().add(yangUnknown);
@@ -936,7 +922,7 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.config != null) {
          statements.add(this.config);
       }
@@ -968,4 +954,3 @@ public class DeviateImpl extends YangBuiltInStatementImpl implements Deviate {
       return statements;
    }
 }
-

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DeviationImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/DeviationImpl.java
@@ -22,7 +22,6 @@ import org.yangcentral.yangkit.util.ModelUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 public class DeviationImpl extends YangBuiltInStatementImpl implements Deviation {
@@ -30,7 +29,7 @@ public class DeviationImpl extends YangBuiltInStatementImpl implements Deviation
    private Reference reference;
    private SchemaNode target;
    private SchemaPath targetPath;
-   private List<Deviate> deviates = new ArrayList();
+   private List<Deviate> deviates = new ArrayList<>();
 
    public DeviationImpl(String argStr) {
       super(argStr);
@@ -106,27 +105,22 @@ public class DeviationImpl extends YangBuiltInStatementImpl implements Deviation
 
       matched = this.getSubStatement(YangBuiltinKeyword.DEVIATE.getQName());
       if (matched.size() != 0) {
-         Iterator iterator;
          YangStatement subStatement;
          if (matched.size() > 1) {
-            iterator = matched.iterator();
-
-            while(iterator.hasNext()) {
-               subStatement = (YangStatement)iterator.next();
-               Deviate deviate = (Deviate)subStatement;
+            for (YangStatement yangStatement : matched) {
+               subStatement = yangStatement;
+               Deviate deviate = (Deviate) subStatement;
                if (DeviateType.forValue(deviate.getArgStr()) == DeviateType.NOT_SUPPORTED) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(deviate,
-                          ErrorCode.DEVIATE_NOT_SUPPORT_ONLY_ONE.getFieldName()));
+                      ErrorCode.DEVIATE_NOT_SUPPORT_ONLY_ONE.getFieldName()));
                   return validatorResultBuilder.build();
                }
             }
          }
 
-         iterator = matched.iterator();
-
-         while(iterator.hasNext()) {
-            subStatement = (YangStatement)iterator.next();
-            this.deviates.add((Deviate)subStatement);
+         for (YangStatement yangStatement : matched) {
+            subStatement = yangStatement;
+            this.deviates.add((Deviate) subStatement);
          }
       }
 
@@ -138,8 +132,6 @@ public class DeviationImpl extends YangBuiltInStatementImpl implements Deviation
       ValidatorRecordBuilder validatorRecordBuilder;
       switch (phase) {
          case GRAMMAR:{
-
-
             break;
          }
 
@@ -161,10 +153,8 @@ public class DeviationImpl extends YangBuiltInStatementImpl implements Deviation
                }
 
                this.setTarget(targetNode);
-               Iterator deviateIterator = this.deviates.iterator();
 
-               while(deviateIterator.hasNext()) {
-                  Deviate deviate = (Deviate)deviateIterator.next();
+               for (Deviate deviate : this.deviates) {
                   deviate.setTarget(targetNode);
                }
             } catch (ModelException e) {
@@ -182,7 +172,7 @@ public class DeviationImpl extends YangBuiltInStatementImpl implements Deviation
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.description != null) {
          statements.add(this.description);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/EntityImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/EntityImpl.java
@@ -78,7 +78,7 @@ public abstract class EntityImpl extends YangStatementImpl implements Entity {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.description != null) {
          statements.add(this.description);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ExtensionImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ExtensionImpl.java
@@ -44,7 +44,7 @@ public class ExtensionImpl extends EntityImpl implements Extension {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.argument != null) {
          statements.add(this.argument);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/FeatureImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/FeatureImpl.java
@@ -9,7 +9,6 @@ import org.yangcentral.yangkit.model.api.stmt.IfFeature;
 import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class FeatureImpl extends EntityImpl implements Feature {
@@ -80,11 +79,9 @@ public class FeatureImpl extends EntityImpl implements Feature {
       validatorResultBuilder.merge(super.initSelf());
 
       List<YangStatement> matched = this.getSubStatement(YangBuiltinKeyword.IFFEATURE.getQName());
-      Iterator statementIterator = matched.iterator();
 
-      while(statementIterator.hasNext()) {
-         YangStatement statement = (YangStatement)statementIterator.next();
-         IfFeature ifFeature = (IfFeature)statement;
+      for (YangStatement statement : matched) {
+         IfFeature ifFeature = (IfFeature) statement;
          validatorResultBuilder.merge(this.addIfFeature(ifFeature));
       }
 
@@ -92,7 +89,7 @@ public class FeatureImpl extends EntityImpl implements Feature {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(this.ifFeatureSupport.getIfFeatures());
       statements.addAll(super.getEffectiveSubStatements());
       return statements;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/GroupingDefContainerImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/GroupingDefContainerImpl.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class GroupingDefContainerImpl implements GroupingDefContainer {
-   private List<Grouping> groupings = new ArrayList();
+   private List<Grouping> groupings = new ArrayList<>();
    private YangContext yangContext;
 
    public List<Grouping> getGroupings() {
@@ -53,11 +53,10 @@ public class GroupingDefContainerImpl implements GroupingDefContainer {
       if (orig != null) {
          validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(orig, grouping));
          grouping.setErrorStatement(true);
-         return validatorResultBuilder.build();
       } else {
          this.groupings.add(grouping);
          this.getYangContext().getGroupingIdentifierCache().put(grouping.getArgStr(), grouping);
-         return validatorResultBuilder.build();
       }
+      return validatorResultBuilder.build();
    }
 }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/GroupingImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/GroupingImpl.java
@@ -26,7 +26,7 @@ public class GroupingImpl extends EntityImpl implements Grouping {
    private DataDefContainerImpl dataDefContainer = new DataDefContainerImpl();
    private GroupingDefContainerImpl groupingDefContainer = new GroupingDefContainerImpl();
    private NotificationContainerImpl notificationContainer = new NotificationContainerImpl();
-   private List<YangStatement> referencedBys = new ArrayList();
+   private List<YangStatement> referencedBys = new ArrayList<>();
    private TypedefContainerImpl typedefContainer = new TypedefContainerImpl();
 
    public void setContext(YangContext context) {
@@ -227,7 +227,7 @@ public class GroupingImpl extends EntityImpl implements Grouping {
 
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(this.actionContainer.getActions());
       statements.addAll(this.dataDefContainer.getDataDefChildren());
       statements.addAll(this.groupingDefContainer.getGroupings());

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/IdentityImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/IdentityImpl.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class IdentityImpl extends EntityImpl implements Identity {
    private IfFeatureSupportImpl ifFeatureSupport = new IfFeatureSupportImpl();
-   private List<Base> bases = new ArrayList();
+   private List<Base> bases = new ArrayList<>();
 
    public IdentityImpl(String argStr) {
       super(argStr);
@@ -28,7 +28,7 @@ public class IdentityImpl extends EntityImpl implements Identity {
    }
 
    public Base getBase(String name) {
-      Iterator baseIterator = this.bases.iterator();
+      Iterator<Base> baseIterator = this.bases.iterator();
 
       Base base;
       do {
@@ -36,7 +36,7 @@ public class IdentityImpl extends EntityImpl implements Identity {
             return null;
          }
 
-         base = (Base)baseIterator.next();
+         base = baseIterator.next();
       } while(!base.getArgStr().equals(name));
 
       return base;
@@ -46,7 +46,7 @@ public class IdentityImpl extends EntityImpl implements Identity {
       if (this.bases.size() == 0) {
          return false;
       } else {
-         Iterator baseIterator = this.bases.iterator();
+         Iterator<Base> baseIterator = this.bases.iterator();
 
          Base base;
          do {
@@ -54,7 +54,7 @@ public class IdentityImpl extends EntityImpl implements Identity {
                return false;
             }
 
-            base = (Base)baseIterator.next();
+            base = baseIterator.next();
          } while(!base.getIdentity().isDerivedOrSelf(other));
 
          return true;
@@ -67,7 +67,7 @@ public class IdentityImpl extends EntityImpl implements Identity {
       } else if (this.bases.size() == 0) {
          return false;
       } else {
-         Iterator baseIterator = this.bases.iterator();
+         Iterator<Base> baseIterator = this.bases.iterator();
 
          Base base;
          do {
@@ -75,7 +75,7 @@ public class IdentityImpl extends EntityImpl implements Identity {
                return false;
             }
 
-            base = (Base)baseIterator.next();
+            base = baseIterator.next();
          } while(!base.getIdentity().isDerivedOrSelf(other));
 
          return true;
@@ -149,13 +149,8 @@ public class IdentityImpl extends EntityImpl implements Identity {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.initSelf());
 
       List<YangStatement> matched = this.getSubStatement(YangBuiltinKeyword.BASE.getQName());
-      Iterator iterator;
-      YangStatement statement;
       if (matched.size() > 0) {
-         iterator = matched.iterator();
-
-         while(iterator.hasNext()) {
-            statement = (YangStatement)iterator.next();
+         for (YangStatement statement : matched) {
             Base base = (Base)statement;
             Base orig = this.getBase(base.getArgStr());
             if (orig != null) {
@@ -168,10 +163,8 @@ public class IdentityImpl extends EntityImpl implements Identity {
       }
 
       matched = this.getSubStatement(YangBuiltinKeyword.IFFEATURE.getQName());
-      iterator = matched.iterator();
 
-      while(iterator.hasNext()) {
-         statement = (YangStatement)iterator.next();
+      for (YangStatement statement : matched) {
          IfFeature ifFeature = (IfFeature)statement;
          validatorResultBuilder.merge(this.addIfFeature(ifFeature));
       }
@@ -189,7 +182,7 @@ public class IdentityImpl extends EntityImpl implements Identity {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(this.ifFeatureSupport.getIfFeatures());
       statements.addAll(this.bases);
       statements.addAll(super.getEffectiveSubStatements());

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/IfFeatureImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/IfFeatureImpl.java
@@ -147,26 +147,19 @@ public class IfFeatureImpl extends YangSimpleStatementImpl implements IfFeature 
          } else {
             Module curModule = this.feature.getContext().getCurModule();
             List<ModuleSet> moduleSets = yangSchema.getModuleSets();
-            Iterator moduleSetIterator = moduleSets.iterator();
 
-            while(moduleSetIterator.hasNext()) {
-               ModuleSet moduleSet = (ModuleSet)moduleSetIterator.next();
+            for (ModuleSet moduleSet : moduleSets) {
                boolean matchedModule = false;
-               Iterator moduleDescriptionIterator = moduleSet.getModules().iterator();
 
-               while(moduleDescriptionIterator.hasNext()) {
-                  YangModuleDescription moduleDescription = (YangModuleDescription)moduleDescriptionIterator.next();
-                  Iterator iterator;
+               for (YangModuleDescription moduleDescription : moduleSet.getModules()) {
                   if (curModule instanceof MainModule) {
-                     if (moduleDescription.getModuleId().equals(new ModuleId(curModule.getArgStr(), curModule.getCurRevisionDate().isPresent() ? (String)curModule.getCurRevisionDate().get() : null))) {
+                     if (moduleDescription.getModuleId().equals(new ModuleId(curModule.getArgStr(), curModule.getCurRevisionDate().isPresent() ? curModule.getCurRevisionDate().get() : null))) {
                         matchedModule = true;
                      }
                   } else {
-                     iterator = moduleDescription.getSubModules().iterator();
 
-                     while(iterator.hasNext()) {
-                        ModuleId subModuleDescription = (ModuleId)iterator.next();
-                        if (subModuleDescription.equals(new ModuleId(curModule.getArgStr(), curModule.getCurRevisionDate().isPresent() ? (String)curModule.getCurRevisionDate().get() : null))) {
+                     for (ModuleId subModuleDescription : moduleDescription.getSubModules()) {
+                        if (subModuleDescription.equals(new ModuleId(curModule.getArgStr(), curModule.getCurRevisionDate().isPresent() ? curModule.getCurRevisionDate().get() : null))) {
                            matchedModule = true;
                            break;
                         }
@@ -174,7 +167,7 @@ public class IfFeatureImpl extends YangSimpleStatementImpl implements IfFeature 
                   }
 
                   if (matchedModule) {
-                     iterator = moduleDescription.getFeatures().iterator();
+                     Iterator<String> iterator = moduleDescription.getFeatures().iterator();
 
                      String featureStr;
                      do {
@@ -182,8 +175,8 @@ public class IfFeatureImpl extends YangSimpleStatementImpl implements IfFeature 
                            return false;
                         }
 
-                        featureStr = (String)iterator.next();
-                     } while(!this.feature.getArgStr().equals(featureStr));
+                        featureStr = iterator.next();
+                     } while (!this.feature.getArgStr().equals(featureStr));
 
                      return true;
                   }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/IfFeatureSupportImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/IfFeatureSupportImpl.java
@@ -13,7 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class IfFeatureSupportImpl implements IfFeatureSupport {
-   private List<IfFeature> ifFeatures = new ArrayList();
+   private List<IfFeature> ifFeatures = new ArrayList<>();
    private YangContext yangContext;
 
    public YangContext getYangContext() {
@@ -56,7 +56,7 @@ public class IfFeatureSupportImpl implements IfFeatureSupport {
 
    public ValidatorResult addIfFeature(IfFeature ifFeature) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator iterator = this.ifFeatures.iterator();
+      Iterator<IfFeature> iterator = this.ifFeatures.iterator();
 
       IfFeature feature;
       do {
@@ -65,7 +65,7 @@ public class IfFeatureSupportImpl implements IfFeatureSupport {
             return validatorResultBuilder.build();
          }
 
-         feature = (IfFeature)iterator.next();
+         feature = iterator.next();
       } while(!feature.getArgStr().equals(ifFeature.getArgStr()));
 
       validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(feature, ifFeature));
@@ -78,7 +78,7 @@ public class IfFeatureSupportImpl implements IfFeatureSupport {
    }
 
    public boolean evaluateFeatures() {
-      Iterator ifFeatureIterator = this.ifFeatures.iterator();
+      Iterator<IfFeature> ifFeatureIterator = this.ifFeatures.iterator();
 
       IfFeature ifFeature;
       do {
@@ -86,7 +86,7 @@ public class IfFeatureSupportImpl implements IfFeatureSupport {
             return true;
          }
 
-         ifFeature = (IfFeature)ifFeatureIterator.next();
+         ifFeature = ifFeatureIterator.next();
       } while(ifFeature.evaluate());
 
       return false;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ImportImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ImportImpl.java
@@ -201,7 +201,7 @@ public class ImportImpl extends YangStatementImpl implements Import {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.prefix != null) {
          statements.add(this.prefix);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/IncludeImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/IncludeImpl.java
@@ -185,7 +185,7 @@ public class IncludeImpl extends YangStatementImpl implements Include {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.description != null) {
          statements.add(this.description);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/InputImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/InputImpl.java
@@ -21,7 +21,6 @@ import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.model.impl.schema.AbsoluteSchemaPath;
 import org.yangcentral.yangkit.xpath.impl.XPathUtil;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class InputImpl extends SchemaNodeImpl implements Input {
@@ -42,14 +41,14 @@ public class InputImpl extends SchemaNodeImpl implements Input {
          SchemaNodeContainer parent = this.getParentSchemaNode();
          if (parent instanceof SchemaNode) {
             schemaPath = new AbsoluteSchemaPath(((SchemaNode)parent).getSchemaPath().getPath());
-            ((SchemaPath.Absolute)schemaPath).addStep(this.getIdentifier());
+            schemaPath.addStep(this.getIdentifier());
          } else {
             schemaPath = new AbsoluteSchemaPath();
-            ((SchemaPath.Absolute)schemaPath).addStep(this.getIdentifier());
+            schemaPath.addStep(this.getIdentifier());
          }
       }
 
-      return (SchemaPath.Absolute)schemaPath;
+      return schemaPath;
    }
 
    public void setContext(YangContext context) {
@@ -222,12 +221,10 @@ public class InputImpl extends SchemaNodeImpl implements Input {
 
    protected ValidatorResult initSelf() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.initSelf());
-      Iterator elementIterator = this.getSubElements().iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
             switch (builtinKeyword) {
                case ANYDATA:
@@ -238,18 +235,18 @@ public class InputImpl extends SchemaNodeImpl implements Input {
                case LEAFLIST:
                case LIST:
                case USES:
-                  DataDefinition dataDefinition = (DataDefinition)builtinStatement;
+                  DataDefinition dataDefinition = (DataDefinition) builtinStatement;
                   validatorResultBuilder.merge(this.addDataDefChild(dataDefinition));
                   break;
                case GROUPING:
-                  Grouping grouping = (Grouping)builtinStatement;
+                  Grouping grouping = (Grouping) builtinStatement;
                   validatorResultBuilder.merge(this.groupingDefContainer.addGrouping(grouping));
                   break;
                case TYPEDEF:
-                  Typedef typedef = (Typedef)builtinStatement;
+                  Typedef typedef = (Typedef) builtinStatement;
                   validatorResultBuilder.merge(this.typedefContainer.addTypedef(typedef));
                   break;
-               case MUST:{
+               case MUST: {
                   Must must = (Must) builtinStatement;
                   validatorResultBuilder.merge(this.mustSupport.addMust(must));
                }
@@ -271,10 +268,7 @@ public class InputImpl extends SchemaNodeImpl implements Input {
       switch (phase) {
          case SCHEMA_BUILD:
 
-            Iterator dataDefinitionIterator = this.getDataDefChildren().iterator();
-
-            while(dataDefinitionIterator.hasNext()) {
-               DataDefinition dataDefinition = (DataDefinition)dataDefinitionIterator.next();
+            for (DataDefinition dataDefinition : this.getDataDefChildren()) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
             }
          default:
@@ -300,7 +294,7 @@ public class InputImpl extends SchemaNodeImpl implements Input {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(getEffectiveSchemaNodeChildren());
       statements.addAll(this.groupingDefContainer.getGroupings());
       statements.addAll(this.typedefContainer.getTypedefs());

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/KeyImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/KeyImpl.java
@@ -1,10 +1,8 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
-import org.yangcentral.yangkit.base.BuildPhase;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
-import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
+
 import org.yangcentral.yangkit.model.api.stmt.Key;
 import org.yangcentral.yangkit.model.api.stmt.Leaf;
 
@@ -14,7 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class KeyImpl extends YangBuiltInStatementImpl implements Key {
-   private List<Leaf> keyNodes = new ArrayList();
+   private List<Leaf> keyNodes = new ArrayList<>();
 
    public KeyImpl(String argStr) {
       super(argStr);
@@ -25,7 +23,7 @@ public class KeyImpl extends YangBuiltInStatementImpl implements Key {
    }
 
    public boolean addKeyNode(Leaf keyNode) {
-      Iterator leafIterator = this.keyNodes.iterator();
+      Iterator<Leaf> leafIterator = this.keyNodes.iterator();
 
       Leaf key;
       do {
@@ -33,7 +31,7 @@ public class KeyImpl extends YangBuiltInStatementImpl implements Key {
             return this.keyNodes.add(keyNode);
          }
 
-         key = (Leaf)leafIterator.next();
+         key = leafIterator.next();
       } while(!key.getArgStr().equals(keyNode.getArgStr()));
 
       return false;
@@ -42,7 +40,7 @@ public class KeyImpl extends YangBuiltInStatementImpl implements Key {
 
 
    public Leaf getKeyNode(QName identifier) {
-      Iterator leafIterator = this.keyNodes.iterator();
+      Iterator<Leaf> leafIterator = this.keyNodes.iterator();
 
       Leaf key;
       do {
@@ -50,7 +48,7 @@ public class KeyImpl extends YangBuiltInStatementImpl implements Key {
             return null;
          }
 
-         key = (Leaf)leafIterator.next();
+         key = leafIterator.next();
       } while(!key.getIdentifier().equals(identifier));
 
       return key;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/LeafImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/LeafImpl.java
@@ -102,7 +102,7 @@ public class LeafImpl extends TypedDataNodeImpl implements Leaf {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.mandatory != null) {
          statements.add(this.mandatory);
       } else {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/LeafListImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/LeafListImpl.java
@@ -4,7 +4,6 @@ import org.yangcentral.yangkit.base.ErrorCode;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.base.YangContext;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.Default;
@@ -20,7 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class LeafListImpl extends TypedDataNodeImpl implements LeafList {
-   private List<Default> defaults = new ArrayList();
+   private List<Default> defaults = new ArrayList<>();
    private MinElements minElements;
    private MaxElements maxElements;
    private OrderedBy orderedBy;
@@ -37,7 +36,7 @@ public class LeafListImpl extends TypedDataNodeImpl implements LeafList {
       if (!this.getDefaults().isEmpty()) {
          return this.defaults;
       } else {
-         List<Default> effectiveDefaults = new ArrayList();
+         List<Default> effectiveDefaults = new ArrayList<>();
          if (this.getType().isDerivedType()) {
             Default effectiveDefault = this.getType().getDerived().getEffectiveDefault();
             if (effectiveDefault != null) {
@@ -54,7 +53,7 @@ public class LeafListImpl extends TypedDataNodeImpl implements LeafList {
    }
 
    public Default getDefault(String value) {
-      Iterator defaultIterator = this.defaults.iterator();
+      Iterator<Default> defaultIterator = this.defaults.iterator();
 
       Default defl;
       do {
@@ -62,7 +61,7 @@ public class LeafListImpl extends TypedDataNodeImpl implements LeafList {
             return null;
          }
 
-         defl = (Default)defaultIterator.next();
+         defl = defaultIterator.next();
       } while(!defl.getArgStr().equals(value));
 
       return defl;
@@ -183,7 +182,6 @@ public class LeafListImpl extends TypedDataNodeImpl implements LeafList {
 
       matched = this.getSubStatement(YangBuiltinKeyword.DEFAULT.getQName());
       if (matched.size() > 0) {
-         ValidatorRecordBuilder validatorRecordBuilder;
          if (this.minElements != null) {
             validatorResultBuilder.merge(this.minElements.init());
             if (this.minElements.getValue() > 0) {
@@ -200,11 +198,8 @@ public class LeafListImpl extends TypedDataNodeImpl implements LeafList {
             }
          }
 
-         Iterator statementIterator = matched.iterator();
-
-         while(statementIterator.hasNext()) {
-            YangStatement subStatement = (YangStatement)statementIterator.next();
-            this.defaults.add((Default)subStatement);
+         for (YangStatement subStatement : matched) {
+            this.defaults.add((Default) subStatement);
          }
       }
 
@@ -214,10 +209,8 @@ public class LeafListImpl extends TypedDataNodeImpl implements LeafList {
    protected ValidatorResult validateSelf() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.validateSelf());
       List<Default> effectiveDefaults = this.getEffectiveDefaults();
-      Iterator defaultIterator = effectiveDefaults.iterator();
 
-      while(defaultIterator.hasNext()) {
-         Default deflt = (Default)defaultIterator.next();
+      for (Default deflt : effectiveDefaults) {
          validatorResultBuilder.merge(this.validateDefault(deflt));
       }
 
@@ -225,7 +218,7 @@ public class LeafListImpl extends TypedDataNodeImpl implements LeafList {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.defaults.size() > 0) {
          statements.addAll(this.defaults);
       } else if (this.getType().isDerivedType()) {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ListImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ListImpl.java
@@ -29,7 +29,7 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
    private MinElements minElements;
    private MaxElements maxElements;
    private OrderedBy orderedBy;
-   private List<Unique> uniques = new ArrayList();
+   private List<Unique> uniques = new ArrayList<>();
 
    public ListImpl(String argStr) {
       super(argStr);
@@ -76,7 +76,7 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
    }
 
    public Unique getUnique(String arg) {
-      Iterator uniqueIterator = this.uniques.iterator();
+      Iterator<Unique> uniqueIterator = this.uniques.iterator();
 
       Unique unique;
       do {
@@ -84,7 +84,7 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
             return null;
          }
 
-         unique = (Unique)uniqueIterator.next();
+         unique = uniqueIterator.next();
       } while(!unique.getArgStr().equals(arg));
 
       return unique;
@@ -104,7 +104,7 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
       int index = -1;
 
       for(int i = 0; i < this.uniques.size(); ++i) {
-         if (((Unique)this.uniques.get(i)).getArgStr().equals(unique)) {
+         if (this.uniques.get(i).getArgStr().equals(unique)) {
             index = i;
          }
       }
@@ -125,7 +125,7 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
          int index = -1;
 
          for(int i = 0; i < this.uniques.size(); ++i) {
-            if (((Unique)this.uniques.get(i)).getArgStr().equals(unique.getArgStr())) {
+            if (this.uniques.get(i).getArgStr().equals(unique.getArgStr())) {
                index = i;
             }
          }
@@ -262,11 +262,9 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
       validatorResultBuilder.merge(super.initSelf());
 
       List<YangStatement> matched = this.getSubStatement(YangBuiltinKeyword.UNIQUE.getQName());
-      Iterator statementIterator = matched.iterator();
 
-      while(statementIterator.hasNext()) {
-         YangStatement subStatement = (YangStatement)statementIterator.next();
-         this.uniques.add((Unique)subStatement);
+      for (YangStatement subStatement : matched) {
+         this.uniques.add((Unique) subStatement);
       }
 
       matched = this.getSubStatement(YangBuiltinKeyword.KEY.getQName());
@@ -302,45 +300,38 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
 
       if (this.getKey() != null) {
          List<Leaf> keyNodes = this.getKey().getkeyNodes();
-         Iterator iterator = keyNodes.iterator();
 
-         while(iterator.hasNext()) {
-            Leaf keyNode = (Leaf)iterator.next();
+         for (Leaf keyNode : keyNodes) {
             if (this.isConfig() != keyNode.isConfig()) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(keyNode,
-                       ErrorCode.KEY_CONFIG_ATTRIBUTE_DIFF_WITH_LIST.getFieldName()));
+                   ErrorCode.KEY_CONFIG_ATTRIBUTE_DIFF_WITH_LIST.getFieldName()));
             } else if (this.isActive() && !keyNode.isActive()) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(keyNode,
-                       ErrorCode.KEY_NODE_INACTIVE.toString(new String[]{"name=" + keyNode.getArgStr()})));
+                   ErrorCode.KEY_NODE_INACTIVE.toString(new String[]{"name=" + keyNode.getArgStr()})));
             } else {
-               if(getContext().getCurModule().getEffectiveYangVersion().equals(Yang.VERSION_1)
-                       && (keyNode.getType().getRestriction() instanceof Empty)){
+               if (getContext().getCurModule().getEffectiveYangVersion().equals(Yang.VERSION_1)
+                   && (keyNode.getType().getRestriction() instanceof Empty)) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(this.getKey(),
-                          ErrorCode.KEY_NODE_SHOULD_NOT_EMPTY_TYPE.getFieldName()));
+                      ErrorCode.KEY_NODE_SHOULD_NOT_EMPTY_TYPE.getFieldName()));
                }
             }
          }
       }
 
-      Iterator uniqueIterator = this.uniques.iterator();
-
-      while(uniqueIterator.hasNext()) {
-         Unique unique = (Unique)uniqueIterator.next();
+      for (Unique unique : this.uniques) {
          List<Leaf> uniqueNodes = unique.getUniqueNodes();
          Boolean config = null;
-         Iterator uniqueNodeIt = uniqueNodes.iterator();
 
-         while(uniqueNodeIt.hasNext()) {
-            Leaf uniqueNode = (Leaf)uniqueNodeIt.next();
+         for (Leaf uniqueNode : uniqueNodes) {
             if (config == null) {
                config = uniqueNode.isConfig();
             } else {
                if (config != uniqueNode.isConfig()) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(uniqueNode,
-                          ErrorCode.UNIQUE_NODE_CONFIG_ATTRI_DIFF.getFieldName()));
+                      ErrorCode.UNIQUE_NODE_CONFIG_ATTRI_DIFF.getFieldName()));
                } else if (this.isActive() && !uniqueNode.isActive()) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(uniqueNode,
-                          ErrorCode.UNIQUE_NODE_INACTIVE.toString(new String[]{"name=" + uniqueNode.getArgStr()})));
+                      ErrorCode.UNIQUE_NODE_INACTIVE.toString(new String[]{"name=" + uniqueNode.getArgStr()})));
                }
             }
          }
@@ -358,10 +349,7 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
                validatorResultBuilder.merge(this.validateKey(this.getKey()));
             }
 
-            Iterator uniqueIterator = this.getUniques().iterator();
-
-            while(uniqueIterator.hasNext()) {
-               Unique unique = (Unique)uniqueIterator.next();
+            for (Unique unique : this.getUniques()) {
                validatorResultBuilder.merge(this.validateUnique(unique));
             }
             break;
@@ -375,7 +363,7 @@ public class ListImpl extends ContainerDataNodeImpl implements YangList {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.key != null) {
          statements.add(this.key);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MainModuleImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MainModuleImpl.java
@@ -14,7 +14,6 @@ import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.util.ModelUtil;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class MainModuleImpl extends ModuleImpl implements MainModule {
@@ -90,7 +89,7 @@ public class MainModuleImpl extends ModuleImpl implements MainModule {
    }
 
    public List<YangStatement> getEffectiveMetaStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.namespace != null) {
          statements.add(this.namespace);
       }
@@ -104,14 +103,11 @@ public class MainModuleImpl extends ModuleImpl implements MainModule {
    }
 
    public List<YangStatement> getEffectiveDefinitionStatement() {
-      List<YangStatement> statements = new ArrayList();
-      statements.addAll(super.getEffectiveDefinitionStatement());
-      Iterator includeIterator = this.getIncludes().iterator();
+      List<YangStatement> statements = new ArrayList<>(super.getEffectiveDefinitionStatement());
 
-      while(includeIterator.hasNext()) {
-         Include include = (Include)includeIterator.next();
+      for (Include include : this.getIncludes()) {
          if (include.getInclude().isPresent()) {
-            SubModule subModule = (SubModule)include.getInclude().get();
+            SubModule subModule = include.getInclude().get();
             statements.addAll(subModule.getAugments());
          }
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MandatoryImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MandatoryImpl.java
@@ -1,17 +1,11 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
-import org.yangcentral.yangkit.common.api.exception.ErrorTag;
-import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.Mandatory;
-import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.util.ModelUtil;
 
 public class MandatoryImpl extends YangSimpleStatementImpl implements Mandatory {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MaxElementsImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MaxElementsImpl.java
@@ -1,17 +1,11 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
-import org.yangcentral.yangkit.common.api.exception.ErrorTag;
-import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.MaxElements;
-import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.util.ModelUtil;
 
 public class MaxElementsImpl extends YangBuiltInStatementImpl implements MaxElements {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MinElementsImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MinElementsImpl.java
@@ -1,17 +1,11 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
-import org.yangcentral.yangkit.common.api.exception.ErrorTag;
-import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.MinElements;
-import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.util.ModelUtil;
 
 public class MinElementsImpl extends YangSimpleStatementImpl implements MinElements {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ModuleImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ModuleImpl.java
@@ -32,26 +32,26 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    private Reference reference;
    private Organization organization;
    private Contact contact;
-   private List<Import> imports = new ArrayList();
-   private List<Include> includes = new ArrayList();
-   private List<Revision> revisions = new ArrayList();
-   private List<Extension> extensions = new ArrayList();
-   private List<Feature> features = new ArrayList();
-   private List<Identity> identities = new ArrayList();
-   private TypedefContainerImpl typedefContainer = new TypedefContainerImpl();
-   private GroupingDefContainerImpl groupingDefContainer = new GroupingDefContainerImpl();
-   private DataDefContainerImpl dataDefContainer = new DataDefContainerImpl();
-   private List<Rpc> rpcs = new ArrayList();
-   private NotificationContainerImpl notificationContainer = new NotificationContainerImpl();
-   private List<Augment> augments = new ArrayList();
-   private List<Deviation> deviations = new ArrayList();
-   private List<Module> dependentBys = new ArrayList<>();
-   private SchemaNodeContainerImpl schemaNodeContainer = new SchemaNodeContainerImpl(this);
-   protected Map<String, ModuleId> prefixCache = new ConcurrentHashMap();
+   private final List<Import> imports = new ArrayList<>();
+   private final List<Include> includes = new ArrayList<>();
+   private final List<Revision> revisions = new ArrayList<>();
+   private final List<Extension> extensions = new ArrayList<>();
+   private final List<Feature> features = new ArrayList<>();
+   private final List<Identity> identities = new ArrayList<>();
+   private final TypedefContainerImpl typedefContainer = new TypedefContainerImpl();
+   private final GroupingDefContainerImpl groupingDefContainer = new GroupingDefContainerImpl();
+   private final DataDefContainerImpl dataDefContainer = new DataDefContainerImpl();
+   private final List<Rpc> rpcs = new ArrayList<>();
+   private final NotificationContainerImpl notificationContainer = new NotificationContainerImpl();
+   private final List<Augment> augments = new ArrayList<>();
+   private final List<Deviation> deviations = new ArrayList<>();
+   private final List<Module> dependentBys = new ArrayList<>();
+   private final SchemaNodeContainerImpl schemaNodeContainer = new SchemaNodeContainerImpl(this);
+   protected Map<String, ModuleId> prefixCache = new ConcurrentHashMap<>();
 
-   private List<YangDataStructure> structures = new ArrayList<>();
+   private final List<YangDataStructure> structures = new ArrayList<>();
 
-   private List<AugmentStructure> augmentStructures = new ArrayList<>();
+   private final List<AugmentStructure> augmentStructures = new ArrayList<>();
 
    public ModuleImpl(String argStr) {
       super(argStr);
@@ -126,12 +126,12 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    }
 
    public Optional<Revision> getCurRevision() {
-      return this.revisions.size() == 0 ? Optional.empty() : Optional.of((Revision)this.revisions.get(0));
+      return this.revisions.size() == 0 ? Optional.empty() : Optional.of(this.revisions.get(0));
    }
 
    public Optional<String> getCurRevisionDate() {
       Optional<Revision> revisionOptional = this.getCurRevision();
-      return !revisionOptional.isPresent() ? Optional.empty() : Optional.of(((Revision)revisionOptional.get()).getArgStr());
+      return !revisionOptional.isPresent() ? Optional.empty() : Optional.of(revisionOptional.get().getArgStr());
    }
 
    public List<Extension> getExtensions() {
@@ -139,7 +139,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    }
 
    public Extension getExtension(String name) {
-      return (Extension)this.getContext().getExtensionCache().get(name);
+      return this.getContext().getExtensionCache().get(name);
    }
 
    public List<Feature> getFeatures() {
@@ -147,7 +147,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    }
 
    public Feature getFeature(String name) {
-      return (Feature)this.getContext().getFeatureCache().get(name);
+      return this.getContext().getFeatureCache().get(name);
    }
 
    public List<Identity> getIdentities() {
@@ -155,7 +155,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    }
 
    public Identity getIdentity(String name) {
-      return (Identity)this.getContext().getIdentityCache().get(name);
+      return this.getContext().getIdentityCache().get(name);
    }
 
    public List<Augment> getAugments() {
@@ -167,7 +167,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    }
 
    public Rpc getRpc(String name) {
-      SchemaNode schemaNode = (SchemaNode)this.getContext().getSchemaNodeIdentifierCache().get(name);
+      SchemaNode schemaNode = this.getContext().getSchemaNodeIdentifierCache().get(name);
       return null != schemaNode && schemaNode instanceof Rpc ? (Rpc)schemaNode : null;
    }
 
@@ -181,11 +181,11 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
 
    public ModuleId getModuleId() {
       List<YangStatement> revisions = this.getSubStatement(YangBuiltinKeyword.REVISION.getQName());
-      return revisions.isEmpty() ? new ModuleId(this.getArgStr(), "") : new ModuleId(this.getArgStr(), ((YangStatement)revisions.get(0)).getArgStr());
+      return revisions.isEmpty() ? new ModuleId(this.getArgStr(), "") : new ModuleId(this.getArgStr(), revisions.get(0).getArgStr());
    }
 
    public Optional<ModuleId> findModuleByPrefix(String prefix) {
-      ModuleId moduleId = (ModuleId)this.prefixCache.get(prefix);
+      ModuleId moduleId = this.prefixCache.get(prefix);
       return null == moduleId ? Optional.empty() : Optional.of(moduleId);
    }
 
@@ -244,10 +244,8 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
 
    private <T extends YangStatement> ValidatorResult mergeDefintion(Map<String, T> source, List<T> candidate, boolean ignoreDuplicate) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator<T> iterator = candidate.iterator();
 
-      while(iterator.hasNext()) {
-         T entry = iterator.next();
+      for (T entry : candidate) {
          if (source.containsKey(entry.getArgStr())) {
             if (!ignoreDuplicate) {
                ValidatorRecordBuilder<Position, YangStatement> validatorRecordBuilder = new ValidatorRecordBuilder();
@@ -255,10 +253,10 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
                validatorRecordBuilder.setSeverity(Severity.ERROR);
                validatorRecordBuilder.setErrorPath(entry.getElementPosition());
                validatorRecordBuilder.setErrorTag(ErrorTag.BAD_ELEMENT);
-               validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.DUPLICATE_DEFINITION.getFieldName() + " in " + ((YangStatement)source.get(entry.getArgStr())).getElementPosition()));
+               validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.DUPLICATE_DEFINITION.getFieldName() + " in " + source.get(entry.getArgStr()).getElementPosition()));
                validatorResultBuilder.addRecord(ModelUtil.reportError(entry,
-                       ErrorCode.DUPLICATE_DEFINITION.getFieldName() + " in "
-                               + (source.get(entry.getArgStr())).getElementPosition()));
+                   ErrorCode.DUPLICATE_DEFINITION.getFieldName() + " in "
+                       + (source.get(entry.getArgStr())).getElementPosition()));
             }
          } else {
             source.put(entry.getArgStr(), entry);
@@ -274,15 +272,13 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
 
    private <T extends YangStatement> ValidatorResult mergeDefintion(Map<String, T> source, Map<String, T> candidate, boolean ignoreDuplicate) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator<Map.Entry<String, T>> iterator = candidate.entrySet().iterator();
 
-      while(iterator.hasNext()) {
-         Map.Entry<String, T> entry = iterator.next();
+      for (Map.Entry<String, T> entry : candidate.entrySet()) {
          if (source.containsKey(entry.getKey())) {
             if (!ignoreDuplicate) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(entry.getValue(),
-                       ErrorCode.DUPLICATE_DEFINITION.getFieldName() + " in "
-                               + (source.get(entry.getKey())).getElementPosition()));
+                   ErrorCode.DUPLICATE_DEFINITION.getFieldName() + " in "
+                       + (source.get(entry.getKey())).getElementPosition()));
             }
          } else {
             source.put(entry.getKey(), entry.getValue());
@@ -319,35 +315,25 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
 
    private ValidatorResult mergeSubModules() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator includeIterator = this.includes.iterator();
-      while (includeIterator.hasNext()){
-         Include include = (Include) includeIterator.next();
-         if(!include.getInclude().isPresent()){
+      for (Include include : this.includes) {
+         if (!include.getInclude().isPresent()) {
             continue;
          }
-         SubModule includeModule = (SubModule) include.getInclude().get();
+         SubModule includeModule = include.getInclude().get();
          validatorResultBuilder.merge(this.mergeDefintion(this.getContext().getTypedefIdentifierCache(), includeModule.getTypedefs()));
          validatorResultBuilder.merge(this.mergeDefintion(this.getContext().getGroupingIdentifierCache(), includeModule.getGroupings()));
-         Iterator dataDefinitionIterator = includeModule.getDataDefChildren().iterator();
 
-         while (dataDefinitionIterator.hasNext()) {
-            DataDefinition dataDefinition = (DataDefinition) dataDefinitionIterator.next();
+         for (DataDefinition dataDefinition : includeModule.getDataDefChildren()) {
             if (!(dataDefinition instanceof Uses)) {
                this.getContext().getSchemaNodeIdentifierCache().put(dataDefinition.getArgStr(), dataDefinition);
             }
          }
 
-         Iterator rpcIterator = includeModule.getRpcs().iterator();
-
-         while (rpcIterator.hasNext()) {
-            Rpc rpc = (Rpc) rpcIterator.next();
+         for (Rpc rpc : includeModule.getRpcs()) {
             this.getContext().getSchemaNodeIdentifierCache().put(rpc.getArgStr(), rpc);
          }
 
-         Iterator notificationIterator = includeModule.getNotifications().iterator();
-
-         while (notificationIterator.hasNext()) {
-            Notification notification = (Notification) notificationIterator.next();
+         for (Notification notification : includeModule.getNotifications()) {
             this.getContext().getSchemaNodeIdentifierCache().put(notification.getArgStr(), notification);
          }
 
@@ -363,7 +349,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
 
    private ValidatorResult mergeSubModulesSchemaTree() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator includeIterator = this.includes.iterator();
+      Iterator<Include> includeIterator = this.includes.iterator();
 
       while(true) {
          Include include;
@@ -372,26 +358,21 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
                return validatorResultBuilder.build();
             }
 
-            include = (Include)includeIterator.next();
+            include = includeIterator.next();
          } while(!include.getInclude().isPresent());
 
-         SubModule includeModule = (SubModule)include.getInclude().get();
-         Iterator schemaNodeIterator = includeModule.getSchemaNodeChildren().iterator();
+         SubModule includeModule = include.getInclude().get();
 
-         while(schemaNodeIterator.hasNext()) {
-            SchemaNode schemaNode = (SchemaNode)schemaNodeIterator.next();
+         for (SchemaNode schemaNode : includeModule.getSchemaNodeChildren()) {
             validatorResultBuilder.merge(this.addSchemaNodeChild(schemaNode));
          }
       }
    }
 
    private void updateSubModules() {
-      Iterator includeIterator = this.includes.iterator();
-
-      while(includeIterator.hasNext()) {
-         Include include = (Include)includeIterator.next();
+      for (Include include : this.includes) {
          if (include.getInclude().isPresent()) {
-            SubModule includeModule = (SubModule)include.getInclude().get();
+            SubModule includeModule = include.getInclude().get();
             this.mergeDefintion(includeModule.getContext().getTypedefIdentifierCache(), this.getContext().getTypedefIdentifierCache(), true);
             this.mergeDefintion(includeModule.getContext().getGroupingIdentifierCache(), this.getContext().getGroupingIdentifierCache(), true);
             this.mergeDefintion(includeModule.getContext().getSchemaNodeIdentifierCache(), this.getContext().getSchemaNodeIdentifierCache(), true);
@@ -405,12 +386,10 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
 
    private ValidatorResult validateSubModules(BuildPhase phase) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator includeIterator = this.includes.iterator();
 
-      while(includeIterator.hasNext()) {
-         Include include = (Include)includeIterator.next();
+      for (Include include : this.includes) {
          if (include.getInclude().isPresent()) {
-            SubModule includeModule = (SubModule)include.getInclude().get();
+            SubModule includeModule = include.getInclude().get();
             validatorResultBuilder.merge(includeModule.build(phase));
          }
       }
@@ -420,18 +399,16 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
 
    private ValidatorResult validateSubModules(BuildPhase from, BuildPhase to) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator<Include> includeIterator = this.includes.iterator();
 
-      while (includeIterator.hasNext()){
-         Include include = includeIterator.next();
-         if(!include.getInclude().isPresent()){
+      for (Include include : this.includes) {
+         if (!include.getInclude().isPresent()) {
             continue;
          }
-         SubModule includeModule = (SubModule)include.getInclude().get();
+         SubModule includeModule = include.getInclude().get();
          BuildPhase[] buildPhases = BuildPhase.values();
          int length = buildPhases.length;
 
-         for(int i = 0; i < length; ++i) {
+         for (int i = 0; i < length; ++i) {
             BuildPhase buildPhase = buildPhases[i];
             if (buildPhase.compareTo(from) < 0 || buildPhase.compareTo(to) > 0) {
                break;
@@ -478,24 +455,15 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
                validatorResultBuilder.merge(this.validateSubModules(phase));
             }
 
-            Iterator<DataDefinition> definitionIterator = this.getDataDefChildren().iterator();
-
-            while(definitionIterator.hasNext()) {
-               DataDefinition dataDefinition = (DataDefinition)definitionIterator.next();
+            for (DataDefinition dataDefinition : this.getDataDefChildren()) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
             }
 
-            Iterator<Rpc> rpcIterator = this.rpcs.iterator();
-
-            while(rpcIterator.hasNext()) {
-               Rpc rpc = rpcIterator.next();
+            for (Rpc rpc : this.rpcs) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(rpc));
             }
 
-            Iterator<Notification> notificationIterator = this.getNotifications().iterator();
-
-            while(notificationIterator.hasNext()) {
-               Notification notification = (Notification)notificationIterator.next();
+            for (Notification notification : this.getNotifications()) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(notification));
             }
 
@@ -516,30 +484,28 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
                validatorResultBuilder.merge(this.validateSubModules(phase));
             }
 
-            List<Augment> augmentCache = new ArrayList();
+            List<Augment> augmentCache = new ArrayList<>();
             augmentCache.addAll(this.augments);
-            List<Augment> errorCache = new ArrayList();
+            List<Augment> errorCache = new ArrayList<>();
             ValidatorResultBuilder subResultBuilder = new ValidatorResultBuilder();
             int parsedCount = 0;
             do {
                subResultBuilder.clear();
                parsedCount = 0;
-               Iterator<Augment> augmentCacheIt = augmentCache.iterator();
 
-               while(augmentCacheIt.hasNext()) {
-                  Augment augment = augmentCacheIt.next();
+               for (Augment augment : augmentCache) {
                   SchemaPath targetPath = null;
                   try {
-                     targetPath = SchemaPathImpl.from(this, augment,augment.getArgStr());
+                     targetPath = SchemaPathImpl.from(this, augment, augment.getArgStr());
 
                   } catch (ModelException e) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(augment,
-                             e.getSeverity(),ErrorTag.BAD_ELEMENT,e.getDescription()));
+                         e.getSeverity(), ErrorTag.BAD_ELEMENT, e.getDescription()));
                      continue;
                   }
                   if (targetPath instanceof SchemaPath.Descendant) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(augment,
-                             ErrorCode.INVALID_SCHEMAPATH.getFieldName()));
+                         ErrorCode.INVALID_SCHEMAPATH.getFieldName()));
                      continue;
                   } else {
                      augment.setTargetPath(targetPath);
@@ -548,14 +514,14 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
                   SchemaNode target = targetPath.getSchemaNode(this.getContext().getSchemaContext());
                   if (target == null) {
                      subResultBuilder.addRecord(ModelUtil.reportError(augment,
-                             ErrorCode.MISSING_TARGET.getFieldName()));
+                         ErrorCode.MISSING_TARGET.getFieldName()));
                      errorCache.add(augment);
                      continue;
                   }
 
                   if (!(target instanceof Augmentable)) {
-                    subResultBuilder.addRecord(ModelUtil.reportError(augment,
-                             ErrorCode.TARGET_CAN_NOT_AUGMENTED.getFieldName()));
+                     subResultBuilder.addRecord(ModelUtil.reportError(augment,
+                         ErrorCode.TARGET_CAN_NOT_AUGMENTED.getFieldName()));
                      errorCache.add(augment);
                      continue;
                   }
@@ -711,57 +677,32 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
             }
 
             if (orig.getRevisionDate() != null && newImport.getRevisionDate() != null) {
-               if (orig.getRevisionDate().getArgStr().equals(newImport.getRevisionDate().getArgStr())) {
-                  return  false;
-               } else {
-                  return true;
-               }
+               return !orig.getRevisionDate().getArgStr().equals(newImport.getRevisionDate().getArgStr());
             }
             return false;
          }
          case INCLUDE:{
             Include orig = (Include) ModelUtil.checkConflict(subStatement,this.getSubStatement(subStatement.getYangKeyword()));
-            if(orig != null){
-               return false;
-            }
-            return true;
+            return orig == null;
          }
          case REVISION:{
             Revision orig = (Revision) ModelUtil.checkConflict(subStatement,this.getSubStatement(subStatement.getYangKeyword()));
-            if(orig != null){
-               return false;
-            }
-            return true;
+            return orig == null;
          }
          case EXTENSION:{
-            if(getContext().getExtensionCache().containsKey(subStatement.getArgStr())){
-               return false;
-            }
-            return true;
+            return !getContext().getExtensionCache().containsKey(subStatement.getArgStr());
          }
          case FEATURE:{
-            if(getContext().getFeatureCache().containsKey(subStatement.getArgStr())){
-               return false;
-            }
-            return true;
+            return !getContext().getFeatureCache().containsKey(subStatement.getArgStr());
          }
          case IDENTITY:{
-            if(getContext().getIdentityCache().containsKey(subStatement.getArgStr())){
-               return false;
-            }
-            return true;
+            return !getContext().getIdentityCache().containsKey(subStatement.getArgStr());
          }
          case TYPEDEF:{
-            if(getTypedef(subStatement.getArgStr())!= null){
-               return false;
-            }
-            return true;
+            return getTypedef(subStatement.getArgStr()) == null;
          }
          case GROUPING:{
-            if(this.getGrouping(subStatement.getArgStr()) != null){
-               return false;
-            }
-            return true;
+            return this.getGrouping(subStatement.getArgStr()) == null;
          }
          case CONTAINER:
          case LIST:
@@ -772,10 +713,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
          case CHOICE:
          case RPC:
          case NOTIFICATION:{
-            if(getContext().getSchemaNodeIdentifierCache().containsKey(subStatement.getArgStr())){
-               return false;
-            }
-            return true;
+            return !getContext().getSchemaNodeIdentifierCache().containsKey(subStatement.getArgStr());
          }
 
          default:{
@@ -874,7 +812,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
             case EXTENSION:{
                Extension newExtension = (Extension)builtinStatement;
                if (this.getContext().getExtensionCache().containsKey(builtinStatement.getArgStr())) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError((YangStatement)this.getContext().getExtensionCache().get(builtinStatement.getArgStr()), newExtension));
+                  validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(this.getContext().getExtensionCache().get(builtinStatement.getArgStr()), newExtension));
                   newExtension.setErrorStatement(true);
                } else {
                   this.extensions.add(newExtension);
@@ -886,7 +824,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
             case FEATURE:{
                Feature newFeature = (Feature)builtinStatement;
                if (this.getContext().getFeatureCache().containsKey(builtinStatement.getArgStr())) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError((YangStatement)this.getContext().getFeatureCache().get(builtinStatement.getArgStr()), newFeature));
+                  validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(this.getContext().getFeatureCache().get(builtinStatement.getArgStr()), newFeature));
                   newFeature.setErrorStatement(true);
                } else {
                   this.features.add(newFeature);
@@ -898,7 +836,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
             case IDENTITY:{
                Identity newIdentity = (Identity)builtinStatement;
                if (this.getContext().getIdentityCache().containsKey(newIdentity.getArgStr())) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError((YangStatement)this.getContext().getIdentityCache().get(newIdentity.getArgStr()), newIdentity));
+                  validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(this.getContext().getIdentityCache().get(newIdentity.getArgStr()), newIdentity));
                   newIdentity.setErrorStatement(true);
                } else {
                   this.identities.add(newIdentity);
@@ -935,7 +873,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
             case RPC:{
                Rpc newRpc = (Rpc)builtinStatement;
                if (this.getContext().getSchemaNodeIdentifierCache().containsKey(newRpc.getArgStr())) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError((YangStatement)this.getContext().getSchemaNodeIdentifierCache().get(newRpc.getArgStr()), newRpc));
+                  validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(this.getContext().getSchemaNodeIdentifierCache().get(newRpc.getArgStr()), newRpc));
                   newRpc.setErrorStatement(true);
                } else {
                   this.rpcs.add(newRpc);
@@ -1002,7 +940,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    }
 
    public Import getImportByPrefix(String prefix) {
-      Iterator importIterator = this.imports.iterator();
+      Iterator<Import> importIterator = this.imports.iterator();
 
       Import im;
       do {
@@ -1010,14 +948,14 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
             return null;
          }
 
-         im = (Import)importIterator.next();
+         im = importIterator.next();
       } while(!im.getPrefix().getArgStr().equals(prefix));
 
       return im;
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(this.getEffectiveMetaStatements());
       statements.addAll(this.getEffectiveLinkageStatement());
       statements.addAll(this.getEffectiveDefinitionStatement());
@@ -1026,7 +964,7 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    }
 
    public List<YangStatement> getEffectiveMetaStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.yangVersion != null) {
          statements.add(this.yangVersion);
       } else {
@@ -1057,14 +995,14 @@ public abstract class ModuleImpl extends YangStatementImpl implements Module {
    }
 
    public List<YangStatement> getEffectiveLinkageStatement() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(this.imports);
       statements.addAll(this.includes);
       return statements;
    }
 
    public List<YangStatement> getEffectiveDefinitionStatement() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(this.getContext().getExtensionCache().values());
       statements.addAll(this.getContext().getFeatureCache().values());
       statements.addAll(this.getContext().getIdentityCache().values());

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MustImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MustImpl.java
@@ -114,7 +114,7 @@ public class MustImpl extends YangBuiltInStatementImpl implements Must {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.errorMessage != null) {
          statements.add(this.errorMessage);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MustSupportImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/MustSupportImpl.java
@@ -1,17 +1,13 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
 import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilderFactory;
 import org.yangcentral.yangkit.model.api.stmt.Must;
 import org.yangcentral.yangkit.model.api.stmt.MustSupport;
 import org.yangcentral.yangkit.model.api.stmt.SchemaNode;
-import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.util.ModelUtil;
 import org.yangcentral.yangkit.xpath.YangXPath;
 import org.yangcentral.yangkit.xpath.impl.XPathUtil;
@@ -23,16 +19,16 @@ import java.util.Iterator;
 import java.util.List;
 
 public class MustSupportImpl implements MustSupport {
-   private List<Must> musts = new ArrayList();
+   private List<Must> musts = new ArrayList<>();
    private Object contextNode;
    private SchemaNode self;
 
    public Must getMust(int index) {
-      return (Must)this.musts.get(index);
+      return this.musts.get(index);
    }
 
    public Must getMust(String condition) {
-      Iterator mustIterator = this.musts.iterator();
+      Iterator<Must> mustIterator = this.musts.iterator();
 
       Must must;
       do {
@@ -40,7 +36,7 @@ public class MustSupportImpl implements MustSupport {
             return null;
          }
 
-         must = (Must)mustIterator.next();
+         must = mustIterator.next();
       } while(!must.getArgStr().equals(condition));
 
       return must;
@@ -71,7 +67,7 @@ public class MustSupportImpl implements MustSupport {
       int index = -1;
 
       for(int i = 0; i < size; ++i) {
-         Must must = (Must)this.musts.get(i);
+         Must must = this.musts.get(i);
          if (must != null && must.getArgStr().equals(condition)) {
             index = i;
             break;
@@ -135,12 +131,10 @@ public class MustSupportImpl implements MustSupport {
 
    public ValidatorResult validateMusts() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator<Must> mustIterator = this.musts.iterator();
 
-      while(mustIterator.hasNext()) {
-         Must must = mustIterator.next();
+      for (Must must : this.musts) {
          YangXPath xpath = must.getXPathExpression();
-         if(xpath == null){
+         if (xpath == null) {
             continue;
          }
          Object contextNode = XPathUtil.getXPathContextNode(self);

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/NotificationContainerImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/NotificationContainerImpl.java
@@ -14,7 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 
 class NotificationContainerImpl implements NotificationContainer {
-   private List<Notification> notifications = new ArrayList();
+   private List<Notification> notifications = new ArrayList<>();
    private YangContext yangContext;
 
    public YangContext getYangContext() {
@@ -30,7 +30,7 @@ class NotificationContainerImpl implements NotificationContainer {
    }
 
    public Notification getNotification(String name) {
-      Iterator iterator = this.notifications.iterator();
+      Iterator<Notification> iterator = this.notifications.iterator();
 
       Notification notification;
       do {
@@ -38,7 +38,7 @@ class NotificationContainerImpl implements NotificationContainer {
             return null;
          }
 
-         notification = (Notification)iterator.next();
+         notification = iterator.next();
       } while(!notification.getArgStr().equals(name));
 
       return notification;
@@ -62,7 +62,7 @@ class NotificationContainerImpl implements NotificationContainer {
 
    public ValidatorResult addNotification(Notification notification) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      SchemaNode schemaNode = (SchemaNode)this.getYangContext().getSchemaNodeIdentifierCache().get(notification.getArgStr());
+      SchemaNode schemaNode = this.getYangContext().getSchemaNodeIdentifierCache().get(notification.getArgStr());
       if (null != schemaNode) {
          validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(schemaNode, notification));
          notification.setErrorStatement(true);

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/NotificationImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/NotificationImpl.java
@@ -19,7 +19,6 @@ import org.yangcentral.yangkit.model.api.stmt.YangBuiltinStatement;
 import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class NotificationImpl extends SchemaNodeImpl implements Notification {
@@ -209,22 +208,20 @@ public class NotificationImpl extends SchemaNodeImpl implements Notification {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       validatorResultBuilder.merge(super.initSelf());
       List<YangElement> subElements = this.getSubElements();
-      Iterator elementIterator = subElements.iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : subElements) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
             switch (builtinKeyword) {
                case TYPEDEF:
 
-                  Typedef newTypedef = (Typedef)builtinStatement;
+                  Typedef newTypedef = (Typedef) builtinStatement;
                   validatorResultBuilder.merge(this.typedefContainer.addTypedef(newTypedef));
                   break;
                case GROUPING:
 
-                  Grouping newGrouping = (Grouping)builtinStatement;
+                  Grouping newGrouping = (Grouping) builtinStatement;
                   validatorResultBuilder.merge(this.groupingDefContainer.addGrouping(newGrouping));
                   break;
                case CONTAINER:
@@ -235,15 +232,15 @@ public class NotificationImpl extends SchemaNodeImpl implements Notification {
                case ANYXML:
                case CHOICE:
                case USES:
-                  DataDefinition newDataDefinition = (DataDefinition)builtinStatement;
+                  DataDefinition newDataDefinition = (DataDefinition) builtinStatement;
                   validatorResultBuilder.merge(this.addDataDefChild(newDataDefinition));
                   break;
                case IFFEATURE:
-                  IfFeature ifFeature = (IfFeature)builtinStatement;
+                  IfFeature ifFeature = (IfFeature) builtinStatement;
                   validatorResultBuilder.merge(this.addIfFeature(ifFeature));
                   break;
                case MUST:
-                  Must must = (Must)builtinStatement;
+                  Must must = (Must) builtinStatement;
                   validatorResultBuilder.merge(this.addMust(must));
             }
          }
@@ -294,11 +291,7 @@ public class NotificationImpl extends SchemaNodeImpl implements Notification {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.buildSelf(phase));
       switch (phase) {
          case SCHEMA_BUILD:
-
-            Iterator dataDefinitionIterator = this.getDataDefChildren().iterator();
-
-            while(dataDefinitionIterator.hasNext()) {
-               DataDefinition dataDefinition = (DataDefinition)dataDefinitionIterator.next();
+            for (DataDefinition dataDefinition : this.getDataDefChildren()) {
                validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
             }
          default:
@@ -324,7 +317,7 @@ public class NotificationImpl extends SchemaNodeImpl implements Notification {
       return schemaNodeContainer.getEffectiveSchemaNodeChildren(ignoreNamespace);
    }
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(getEffectiveSchemaNodeChildren());
       statements.addAll(this.ifFeatureSupport.getIfFeatures());
       statements.addAll(this.groupingDefContainer.getGroupings());

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/OperationImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/OperationImpl.java
@@ -189,13 +189,8 @@ public abstract class OperationImpl extends SchemaNodeImpl implements Operation 
         ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.initSelf());
 
         List<YangStatement> matched = this.getSubStatement(YangBuiltinKeyword.GROUPING.getQName());
-        Iterator iterator;
-        YangStatement statement;
         if (matched.size() > 0) {
-            iterator = matched.iterator();
-
-            while(iterator.hasNext()) {
-                statement = (YangStatement)iterator.next();
+            for (YangStatement statement : matched) {
                 Grouping grouping = (Grouping)statement;
                 validatorResultBuilder.merge(this.groupingDefContainer.addGrouping(grouping));
             }
@@ -203,10 +198,7 @@ public abstract class OperationImpl extends SchemaNodeImpl implements Operation 
 
         matched = this.getSubStatement(YangBuiltinKeyword.TYPEDEF.getQName());
         if (matched.size() > 0) {
-            iterator = matched.iterator();
-
-            while(iterator.hasNext()) {
-                statement = (YangStatement)iterator.next();
+            for (YangStatement statement : matched) {
                 Typedef typedef = (Typedef)statement;
                 validatorResultBuilder.merge(this.typedefContainer.addTypedef(typedef));
             }
@@ -214,10 +206,7 @@ public abstract class OperationImpl extends SchemaNodeImpl implements Operation 
 
         matched = this.getSubStatement(YangBuiltinKeyword.IFFEATURE.getQName());
         if (matched.size() > 0) {
-            iterator = matched.iterator();
-
-            while(iterator.hasNext()) {
-                statement = (YangStatement)iterator.next();
+            for (YangStatement statement : matched) {
                 IfFeature ifFeature = (IfFeature)statement;
                 validatorResultBuilder.merge(this.ifFeatureSupport.addIfFeature(ifFeature));
             }
@@ -285,7 +274,7 @@ public abstract class OperationImpl extends SchemaNodeImpl implements Operation 
     }
 
     public List<YangStatement> getEffectiveSubStatements() {
-        List<YangStatement> statements = new ArrayList();
+        List<YangStatement> statements = new ArrayList<>();
         statements.addAll(this.groupingDefContainer.getGroupings());
         statements.addAll(this.typedefContainer.getTypedefs());
         if (this.input != null && this.input.isActive()) {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/OrderedByImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/OrderedByImpl.java
@@ -1,18 +1,12 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
-import org.yangcentral.yangkit.common.api.exception.ErrorTag;
-import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.OrderBy;
 import org.yangcentral.yangkit.model.api.stmt.OrderedBy;
-import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.util.ModelUtil;
 
 public class OrderedByImpl extends YangBuiltInStatementImpl implements OrderedBy {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/RefineImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/RefineImpl.java
@@ -8,20 +8,18 @@ import org.yangcentral.yangkit.model.api.schema.SchemaPath;
 import org.yangcentral.yangkit.model.api.stmt.*;
 import org.yangcentral.yangkit.util.ModelUtil;
 import org.yangcentral.yangkit.xpath.impl.XPathUtil;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+
+import java.util.*;
 
 public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
-   private IfFeatureSupportImpl ifFeatureSupport = new IfFeatureSupportImpl();
+   private final IfFeatureSupportImpl ifFeatureSupport = new IfFeatureSupportImpl();
    private SchemaPath targetPath;
    private SchemaNode targetNode;
    private Description description;
    private Reference reference;
-   private MustSupportImpl mustSupport = new MustSupportImpl();
+   private final MustSupportImpl mustSupport = new MustSupportImpl();
    private Config config;
-   private List<Default> defaults = new ArrayList();
+   private final List<Default> defaults = new ArrayList<>();
    private Mandatory mandatory;
    private Presence presence;
    private MaxElements maxElements;
@@ -156,10 +154,9 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 
    protected ValidatorResult buildSelf(BuildPhase phase) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.buildSelf(phase));
-      switch (phase) {
-         case SCHEMA_BUILD:
-            this.mustSupport.setContextNode(XPathUtil.getXPathContextNode(this.targetNode));
-            if (this.description != null) {
+      if (Objects.requireNonNull(phase) == BuildPhase.SCHEMA_BUILD) {
+         this.mustSupport.setContextNode(XPathUtil.getXPathContextNode(this.targetNode));
+         if (this.description != null) {
 //               YangStatement candidate = description.clone();
 //               candidate.setContext(description.getContext());
 //               List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.DESCRIPTION.getQName());
@@ -169,10 +166,10 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                  targetNode.removeChild(statements.get(0));
 //                  targetNode.addChild(candidate);
 //               }
-               targetNode.setDescription(description);
-            }
+            targetNode.setDescription(description);
+         }
 
-            if (this.reference != null) {
+         if (this.reference != null) {
 //               YangStatement candidate = reference.clone();
 //               candidate.setContext(reference.getContext());
 //               List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.REFERENCE.getQName());
@@ -182,10 +179,10 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                  targetNode.removeChild(statements.get(0));
 //                  targetNode.addChild(candidate);
 //               }
-               targetNode.setReference(reference);
-            }
-            if (this.config != null) {
-               if (this.targetNode instanceof ConfigSupport) {
+            targetNode.setReference(reference);
+         }
+         if (this.config != null) {
+            if (this.targetNode instanceof ConfigSupport) {
 //                  YangStatement candidate = config.clone();
 //                  candidate.setContext(config.getContext());
 //                  List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.CONFIG.getQName());
@@ -195,25 +192,22 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                     targetNode.removeChild(statements.get(0));
 //                     targetNode.addChild(candidate);
 //                  }
-                  ConfigSupport configSupport = (ConfigSupport) targetNode;
-                  configSupport.setConfig(config);
-               } else {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(this,
-                          ErrorCode.NOT_SUPPORT_CONFIG.getFieldName()));
-               }
+               ConfigSupport configSupport = (ConfigSupport) targetNode;
+               configSupport.setConfig(config);
+            } else {
+               validatorResultBuilder.addRecord(ModelUtil.reportError(this,
+                   ErrorCode.NOT_SUPPORT_CONFIG.getFieldName()));
             }
+         }
 
-            Iterator iterator;
-            if (this.getIfFeatures().size() > 0) {
-               if (!(this.targetNode instanceof DataNode) && !(this.targetNode instanceof Choice) && !(this.targetNode instanceof Case)) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(this,
-                          ErrorCode.NOT_SUPPORT_IFFEATURE.getFieldName()));
-               } else {
-                  DataDefinition dataDefinition = (DataDefinition)this.targetNode;
-                  iterator = this.getIfFeatures().iterator();
+         if (this.getIfFeatures().size() > 0) {
+            if (!(this.targetNode instanceof DataNode) && !(this.targetNode instanceof Choice) && !(this.targetNode instanceof Case)) {
+               validatorResultBuilder.addRecord(ModelUtil.reportError(this,
+                   ErrorCode.NOT_SUPPORT_IFFEATURE.getFieldName()));
+            } else {
+               DataDefinition dataDefinition = (DataDefinition) this.targetNode;
 
-                  while(iterator.hasNext()) {
-                     IfFeature ifFeature = (IfFeature)iterator.next();
+               for (IfFeature ifFeature : getIfFeatures()) {
 //                     YangStatement candidate = ifFeature.clone();
 //                     candidate.setContext(ifFeature.getContext());
 //                     YangStatement orig = targetNode.getSubStatement(YangBuiltinKeyword.IFFEATURE.getQName(),ifFeature.getArgStr());
@@ -223,18 +217,16 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                        targetNode.removeChild(orig);
 //                        targetNode.addChild(candidate);
 //                     }
-                     dataDefinition.addIfFeature(ifFeature);
-                  }
+                  dataDefinition.addIfFeature(ifFeature);
                }
             }
+         }
 
-            if (this.getMusts().size() > 0) {
-               if (this.targetNode instanceof MustSupport) {
-                  MustSupport mustSupport = (MustSupport)this.targetNode;
-                  iterator = this.getMusts().iterator();
+         if (this.getMusts().size() > 0) {
+            if (this.targetNode instanceof MustSupport) {
+               MustSupport mustSupport = (MustSupport) this.targetNode;
 
-                  while(iterator.hasNext()) {
-                     Must must = (Must)iterator.next();
+               for (Must must : getMusts()) {
 //                     YangStatement candidate = must.clone();
 //                     candidate.setContext(must.getContext());
 //                     YangStatement orig = targetNode.getSubStatement(YangBuiltinKeyword.MUST.getQName(),must.getArgStr());
@@ -244,20 +236,20 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                        targetNode.removeChild(orig);
 //                        targetNode.addChild(candidate);
 //                     }
-                     mustSupport.addMust(must);
-                  }
-               } else {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(this,
-                          ErrorCode.NOT_SUPPORT_MUST.getFieldName()));
+                  mustSupport.addMust(must);
                }
+            } else {
+               validatorResultBuilder.addRecord(ModelUtil.reportError(this,
+                   ErrorCode.NOT_SUPPORT_MUST.getFieldName()));
             }
+         }
 
-            if (this.defaults.size() > 0) {
-               if ((this.targetNode instanceof Leaf) || (this.targetNode instanceof Choice)) {
-                  if (this.defaults.size() > 1) {
-                     validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(1),
-                             ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
-                  }
+         if (this.defaults.size() > 0) {
+            if ((this.targetNode instanceof Leaf) || (this.targetNode instanceof Choice)) {
+               if (this.defaults.size() > 1) {
+                  validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(1),
+                      ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+               }
 //                  YangStatement candidate = defaults.get(0).clone();
 //                  candidate.setContext(defaults.get(0).getContext());
 //                  List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.DEFAULT.getQName());
@@ -265,34 +257,34 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                     targetNode.removeChild(statements.get(0));
 //                  }
 //                  targetNode.addChild(candidate);
-                  if(targetNode instanceof Leaf){
-                     ((Leaf) targetNode).setDefault(defaults.get(0));
-                  } else if(targetNode instanceof Choice){
-                     ((Choice) targetNode).setDefault(defaults.get(0));
-                  }
-               } else if (this.targetNode instanceof LeafList) {
+               if (targetNode instanceof Leaf) {
+                  ((Leaf) targetNode).setDefault(defaults.get(0));
+               } else if (targetNode instanceof Choice) {
+                  ((Choice) targetNode).setDefault(defaults.get(0));
+               }
+            } else if (this.targetNode instanceof LeafList) {
 //                  List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.DEFAULT.getQName());
 //                  for(YangStatement dflt:statements){
 //                     targetNode.removeChild(dflt);
 //                  }
-                  LeafList leafList = (LeafList) targetNode;
-                  leafList.setDefaults(defaults);
+               LeafList leafList = (LeafList) targetNode;
+               leafList.setDefaults(defaults);
 //                  for(Default newDflt:defaults){
 ////                     YangStatement candidate = newDflt.clone();
 ////                     candidate.setContext(newDflt.getContext());
 //                     leafList.addDefault(newDflt);
 //                  }
-               } else {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(0),
-                          ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
-               }
+            } else {
+               validatorResultBuilder.addRecord(ModelUtil.reportError(this.defaults.get(0),
+                   ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
             }
+         }
 
-            if (this.mandatory != null) {
-               if (!(this.targetNode instanceof MandatorySupport)) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(mandatory,
-                          ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
-               } else {
+         if (this.mandatory != null) {
+            if (!(this.targetNode instanceof MandatorySupport)) {
+               validatorResultBuilder.addRecord(ModelUtil.reportError(mandatory,
+                   ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
+            } else {
 //                  YangStatement candidate = mandatory.clone();
 //                  candidate.setContext(mandatory.getContext());
 //                  List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.MANDATORY.getQName());
@@ -302,13 +294,13 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                     targetNode.removeChild(statements.get(0));
 //                     targetNode.addChild(candidate);
 //                  }
-                  MandatorySupport mandatorySupport = (MandatorySupport) targetNode;
-                  mandatorySupport.setMandatory(mandatory);
-               }
+               MandatorySupport mandatorySupport = (MandatorySupport) targetNode;
+               mandatorySupport.setMandatory(mandatory);
             }
+         }
 
-            if (this.presence != null) {
-               if (this.targetNode instanceof Container) {
+         if (this.presence != null) {
+            if (this.targetNode instanceof Container) {
 //                  YangStatement candidate = presence.clone();
 //                  candidate.setContext(presence.getContext());
 //                  List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.PRESENCE.getQName());
@@ -318,17 +310,17 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                     targetNode.removeChild(statements.get(0));
 //                     targetNode.addChild(candidate);
 //                  }
-                  Container container = (Container) targetNode;
-                  container.setPresence(presence);
-               } else {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(presence,
-                          ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
-               }
+               Container container = (Container) targetNode;
+               container.setPresence(presence);
+            } else {
+               validatorResultBuilder.addRecord(ModelUtil.reportError(presence,
+                   ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
             }
+         }
 
-            MultiInstancesDataNode multiInstancesDataNode;
-            if (this.maxElements != null) {
-               if (this.targetNode instanceof MultiInstancesDataNode) {
+         MultiInstancesDataNode multiInstancesDataNode;
+         if (this.maxElements != null) {
+            if (this.targetNode instanceof MultiInstancesDataNode) {
 //                  YangStatement candidate = maxElements.clone();
 //                  candidate.setContext(maxElements.getContext());
 //                  List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.MAXELEMENTS.getQName());
@@ -338,16 +330,16 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                     targetNode.removeChild(statements.get(0));
 //                     targetNode.addChild(candidate);
 //                  }
-                  multiInstancesDataNode = (MultiInstancesDataNode) targetNode;
-                  multiInstancesDataNode.setMaxElements(maxElements);
-               } else {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(maxElements,
-                          ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
-               }
+               multiInstancesDataNode = (MultiInstancesDataNode) targetNode;
+               multiInstancesDataNode.setMaxElements(maxElements);
+            } else {
+               validatorResultBuilder.addRecord(ModelUtil.reportError(maxElements,
+                   ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
             }
+         }
 
-            if (this.minElements != null) {
-               if (this.targetNode instanceof MultiInstancesDataNode) {
+         if (this.minElements != null) {
+            if (this.targetNode instanceof MultiInstancesDataNode) {
 //                  YangStatement candidate = minElements.clone();
 //                  candidate.setContext(minElements.getContext());
 //                  List<YangStatement> statements = targetNode.getSubStatement(YangBuiltinKeyword.MINELEMENTS.getQName());
@@ -357,59 +349,58 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
 //                     targetNode.removeChild(statements.get(0));
 //                     targetNode.addChild(candidate);
 //                  }
-                  multiInstancesDataNode = (MultiInstancesDataNode) targetNode;
-                  multiInstancesDataNode.setMinElements(minElements);
-               } else {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(minElements,
-                          ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
-               }
+               multiInstancesDataNode = (MultiInstancesDataNode) targetNode;
+               multiInstancesDataNode.setMinElements(minElements);
+            } else {
+               validatorResultBuilder.addRecord(ModelUtil.reportError(minElements,
+                   ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
             }
+         }
 
-            if (this.getUnknowns().size() > 0) {
-               YangSpecification yangSpecification = this.targetNode.getContext().getYangSpecification();
-               YangStatementDef yangStatementDef = yangSpecification.getStatementDef(this.targetNode.getYangKeyword());
-               for(YangUnknown unknown:this.getUnknowns()){
-                  boolean isMultiInstance = true;
-                  Cardinality cardinality = yangStatementDef.getSubStatementCardinality(unknown.getYangKeyword());
-                  if(cardinality != null){
-                     if(!cardinality.isUnbounded()&& cardinality.getMaxElements() <=1){
-                        isMultiInstance = false;
-                     }
+         if (this.getUnknowns().size() > 0) {
+            YangSpecification yangSpecification = this.targetNode.getContext().getYangSpecification();
+            YangStatementDef yangStatementDef = yangSpecification.getStatementDef(this.targetNode.getYangKeyword());
+            for (YangUnknown unknown : this.getUnknowns()) {
+               boolean isMultiInstance = true;
+               Cardinality cardinality = yangStatementDef.getSubStatementCardinality(unknown.getYangKeyword());
+               if (cardinality != null) {
+                  if (!cardinality.isUnbounded() && cardinality.getMaxElements() <= 1) {
+                     isMultiInstance = false;
                   }
-                  if(isMultiInstance){
+               }
+               if (isMultiInstance) {
 //                     YangStatement orig = this.targetNode.getSubStatement(unknown.getYangKeyword(),unknown.getArgStr());
 //                     if(orig != null){
 //                        this.targetNode.removeChild(orig);
 //
 //                     }
-                     targetNode.getUnknowns().add(unknown);
-                  } else {
+                  targetNode.getUnknowns().add(unknown);
+               } else {
 //                     List<YangStatement> origs = this.targetNode.getSubStatement(unknown.getYangKeyword());
 //                     if(!origs.isEmpty()){
 //                        this.targetNode.removeChild(origs.get(0));
 //                     }
-                     List<YangUnknown> unknowns = targetNode.getUnknowns(unknown.getYangKeyword());
-                     if(!unknowns.isEmpty()){
-                        targetNode.getUnknowns().remove(unknowns.get(0));
-                     }
-                     targetNode.getUnknowns().add(unknown);
+                  List<YangUnknown> unknowns = targetNode.getUnknowns(unknown.getYangKeyword());
+                  if (!unknowns.isEmpty()) {
+                     targetNode.getUnknowns().remove(unknowns.get(0));
                   }
+                  targetNode.getUnknowns().add(unknown);
+               }
 //                  YangStatement candidate = unknown.clone();
 //                  candidate.setContext(unknown.getContext());
 //                  targetNode.addChild(candidate);
 
-               }
-
             }
+
+         }
 //            ValidatorResult validatorResult = targetNode.init();
 //            if(!validatorResult.isOk()){
 //               validatorResultBuilder.merge(validatorResult);
 //            } else {
 //               validatorResultBuilder.merge(targetNode.build());
 //            }
-         default:
-            return validatorResultBuilder.build();
       }
+      return validatorResultBuilder.build();
    }
 
    @Override
@@ -434,48 +425,45 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
                  ErrorCode.INVALID_ARG.getFieldName() ));
       }
 
-      Iterator elementIterator = this.getSubElements().iterator();
-
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(((YangBuiltinStatement)subElement).getYangKeyword());
+            YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(((YangBuiltinStatement) subElement).getYangKeyword());
             switch (builtinKeyword) {
                case CONFIG:
-                  this.config = (Config)subElement;
+                  this.config = (Config) subElement;
                   break;
                case IFFEATURE:
-                  validatorResultBuilder.merge(this.addIfFeature((IfFeature)subElement));
+                  validatorResultBuilder.merge(this.addIfFeature((IfFeature) subElement));
                   break;
                case DESCRIPTION:
-                  this.description = (Description)subElement;
+                  this.description = (Description) subElement;
                   break;
                case REFERENCE:
-                  this.reference = (Reference)subElement;
+                  this.reference = (Reference) subElement;
                   break;
                case MUST:
-                  validatorResultBuilder.merge(this.addMust((Must)subElement));
+                  validatorResultBuilder.merge(this.addMust((Must) subElement));
                   break;
                case DEFAULT:
-                  Default oldDefault = (Default)ModelUtil.checkConflict((Default)subElement, this.defaults);
+                  Default oldDefault = ModelUtil.checkConflict((Default) subElement, this.defaults);
                   if (oldDefault != null) {
-                     validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(oldDefault, (Default)subElement));
-                     ((Default)subElement).setErrorStatement(true);
+                     validatorResultBuilder.addRecord(ModelUtil.reportDuplicateError(oldDefault, (Default) subElement));
+                     ((Default) subElement).setErrorStatement(true);
                   } else {
-                     this.defaults.add((Default)subElement);
+                     this.defaults.add((Default) subElement);
                   }
                   break;
                case MANDATORY:
-                  this.mandatory = (Mandatory)subElement;
+                  this.mandatory = (Mandatory) subElement;
                   break;
                case PRESENCE:
-                  this.presence = (Presence)subElement;
+                  this.presence = (Presence) subElement;
                   break;
                case MAXELEMENTS:
-                  this.maxElements = (MaxElements)subElement;
+                  this.maxElements = (MaxElements) subElement;
                   break;
                case MINELEMENTS:
-                  this.minElements = (MinElements)subElement;
+                  this.minElements = (MinElements) subElement;
             }
          }
       }
@@ -484,7 +472,7 @@ public class RefineImpl extends YangBuiltInStatementImpl implements Refine {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.config != null) {
          statements.add(this.config);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/RevisionDateImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/RevisionDateImpl.java
@@ -1,17 +1,11 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
-import org.yangcentral.yangkit.common.api.exception.ErrorTag;
-import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.RevisionDate;
-import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.util.ModelUtil;
 
 public class RevisionDateImpl extends YangSimpleStatementImpl implements RevisionDate {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/RevisionImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/RevisionImpl.java
@@ -71,7 +71,7 @@ public class RevisionImpl extends YangSimpleStatementImpl implements Revision {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.description != null) {
          statements.add(this.description);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/SchemaDataNodeImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/SchemaDataNodeImpl.java
@@ -77,7 +77,7 @@ public abstract class SchemaDataNodeImpl extends DataDefinitionImpl implements S
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.config != null) {
          statements.add(this.config);
       } else {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/SchemaNodeContainerImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/SchemaNodeContainerImpl.java
@@ -1,13 +1,8 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
 import org.yangcentral.yangkit.base.YangContext;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
-import org.yangcentral.yangkit.common.api.exception.ErrorTag;
-import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.schema.SchemaTreeType;
@@ -20,7 +15,7 @@ import org.yangcentral.yangkit.util.ModelUtil;
 import java.util.*;
 
 public class SchemaNodeContainerImpl implements SchemaNodeContainer {
-   private List<SchemaNode> schemaNodes = new ArrayList();
+   private List<SchemaNode> schemaNodes = new ArrayList<>();
    private YangContext yangContext;
    private SchemaNodeContainer self;
 
@@ -114,10 +109,8 @@ public class SchemaNodeContainerImpl implements SchemaNodeContainer {
 
    public ValidatorResult addSchemaNodeChildren(List<SchemaNode> schemaNodes) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator schemaNodeIterator = schemaNodes.iterator();
 
-      while(schemaNodeIterator.hasNext()) {
-         SchemaNode node = (SchemaNode)schemaNodeIterator.next();
+      for (SchemaNode node : schemaNodes) {
          ValidatorResult result = this.addSchemaNodeChild(node);
          validatorResultBuilder.merge(result);
       }
@@ -127,12 +120,9 @@ public class SchemaNodeContainerImpl implements SchemaNodeContainer {
 
    public SchemaNode getSchemaNodeChild(QName identifier) {
       try {
-         Iterator schemaNodeIterator = this.schemaNodes.iterator();
-
-         while(schemaNodeIterator.hasNext()) {
-            SchemaNode schemaNode = (SchemaNode)schemaNodeIterator.next();
+         for (SchemaNode schemaNode : this.schemaNodes) {
             if (schemaNode instanceof VirtualSchemaNode) {
-               VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode)schemaNode;
+               VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode) schemaNode;
                SchemaNode node = virtualSchemaNode.getSchemaNodeChild(identifier);
                if (node != null) {
                   return node;
@@ -149,20 +139,18 @@ public class SchemaNodeContainerImpl implements SchemaNodeContainer {
    }
 
    public DataNode getDataNodeChild(QName identifier) {
-      Iterator<SchemaNode> schemaNodeIterator = this.schemaNodes.iterator();
-      while (schemaNodeIterator.hasNext()){
-         SchemaNode schemaNode = schemaNodeIterator.next();
+      for (SchemaNode schemaNode : this.schemaNodes) {
          if (!(schemaNode instanceof VirtualSchemaNode) && !(schemaNode instanceof Choice) && !(schemaNode instanceof Case) && !(schemaNode instanceof Input) && !(schemaNode instanceof Output)) {
             if (schemaNode.getIdentifier().equals(identifier)) {
-               if(schemaNode instanceof DataNode){
+               if (schemaNode instanceof DataNode) {
                   return (DataNode) schemaNode;
                }
                return null;
             }
          } else {
-            SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer)schemaNode;
+            SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer) schemaNode;
             DataNode node = schemaNodeContainer.getDataNodeChild(identifier);
-            if(node !=null){
+            if (node != null) {
                return node;
             }
          }
@@ -172,16 +160,14 @@ public class SchemaNodeContainerImpl implements SchemaNodeContainer {
    }
 
    public List<DataNode> getDataNodeChildren() {
-      List<DataNode> dataNodeChildren = new ArrayList();
-      Iterator<SchemaNode> schemaNodeIterator = this.schemaNodes.iterator();
-      while (schemaNodeIterator.hasNext()){
-         SchemaNode schemaNode = schemaNodeIterator.next();
+      List<DataNode> dataNodeChildren = new ArrayList<>();
+      for (SchemaNode schemaNode : this.schemaNodes) {
          if (!(schemaNode instanceof VirtualSchemaNode) && !(schemaNode instanceof Choice) && !(schemaNode instanceof Case) && !(schemaNode instanceof Input) && !(schemaNode instanceof Output)) {
             if (schemaNode instanceof DataNode) {
-               dataNodeChildren.add((DataNode)schemaNode);
+               dataNodeChildren.add((DataNode) schemaNode);
             }
          } else {
-            SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer)schemaNode;
+            SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer) schemaNode;
             dataNodeChildren.addAll(schemaNodeContainer.getDataNodeChildren());
          }
       }
@@ -217,12 +203,10 @@ public class SchemaNodeContainerImpl implements SchemaNodeContainer {
 
    public void removeSchemaNodeChild(QName identifier) {
       SchemaNode target = null;
-      Iterator iterator = this.schemaNodes.iterator();
 
-      while(iterator.hasNext()) {
-         SchemaNode schemaNode = (SchemaNode)iterator.next();
+      for (SchemaNode schemaNode : this.schemaNodes) {
          if (schemaNode instanceof VirtualSchemaNode) {
-            VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode)schemaNode;
+            VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode) schemaNode;
             virtualSchemaNode.removeSchemaNodeChild(identifier);
          } else if (schemaNode.getIdentifier().equals(identifier)) {
             target = schemaNode;
@@ -239,12 +223,10 @@ public class SchemaNodeContainerImpl implements SchemaNodeContainer {
       if (this.schemaNodes.contains(schemaNode)) {
          this.schemaNodes.remove(schemaNode);
       } else {
-         Iterator iterator = this.schemaNodes.iterator();
 
-         while(iterator.hasNext()) {
-            SchemaNode node = (SchemaNode)iterator.next();
+         for (SchemaNode node : this.schemaNodes) {
             if (node instanceof VirtualSchemaNode) {
-               VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode)node;
+               VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode) node;
                virtualSchemaNode.removeSchemaNodeChild(schemaNode);
             }
          }
@@ -257,13 +239,11 @@ public class SchemaNodeContainerImpl implements SchemaNodeContainer {
    }
 
    public SchemaNode getMandatoryDescendant() {
-      Iterator<SchemaNode> schemaNodeIterator = this.schemaNodes.iterator();
-      while(schemaNodeIterator.hasNext()) {
-         SchemaNode child = schemaNodeIterator.next();
+      for (SchemaNode child : this.schemaNodes) {
          if (!(child instanceof MandatorySupport) && !(child instanceof MultiInstancesDataNode)) {
             SchemaNode schemaNode;
             if (child instanceof Container) {
-               Container container = (Container)child;
+               Container container = (Container) child;
                if (container.getPresence() == null) {
                   schemaNode = container.getMandatoryDescendant();
                   if (schemaNode != null) {
@@ -271,7 +251,7 @@ public class SchemaNodeContainerImpl implements SchemaNodeContainer {
                   }
                }
             } else if (child instanceof SchemaNodeContainer) {
-               SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer)child;
+               SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer) child;
                schemaNode = schemaNodeContainer.getMandatoryDescendant();
                if (schemaNode != null) {
                   return schemaNode;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/SchemaNodeImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/SchemaNodeImpl.java
@@ -20,7 +20,6 @@ import org.yangcentral.yangkit.model.api.stmt.SchemaNodeContainer;
 import org.yangcentral.yangkit.model.api.stmt.VirtualSchemaNode;
 import org.yangcentral.yangkit.model.impl.schema.AbsoluteSchemaPath;
 
-import java.util.Iterator;
 
 public abstract class SchemaNodeImpl extends EntityImpl implements SchemaNode {
    private Boolean support;
@@ -93,10 +92,8 @@ public abstract class SchemaNodeImpl extends EntityImpl implements SchemaNode {
 
          if (this instanceof VirtualSchemaNode || this instanceof Container) {
             SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer)this;
-            Iterator schemaNodeIterator = schemaNodeContainer.getSchemaNodeChildren().iterator();
 
-            while(schemaNodeIterator.hasNext()) {
-               SchemaNode schemaNode = (SchemaNode)schemaNodeIterator.next();
+            for (SchemaNode schemaNode : schemaNodeContainer.getSchemaNodeChildren()) {
                if (schemaNode.isMandatory()) {
                   return true;
                }
@@ -120,10 +117,8 @@ public abstract class SchemaNodeImpl extends EntityImpl implements SchemaNode {
       } else {
          if (this instanceof SchemaNodeContainer) {
             SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer)this;
-            Iterator schemaNodeIterator = schemaNodeContainer.getSchemaNodeChildren().iterator();
 
-            while(schemaNodeIterator.hasNext()) {
-               SchemaNode schemaNode = (SchemaNode)schemaNodeIterator.next();
+            for (SchemaNode schemaNode : schemaNodeContainer.getSchemaNodeChildren()) {
                if (schemaNode.hasDefault()) {
                   return true;
                }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/StatusImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/StatusImpl.java
@@ -1,18 +1,12 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
-import org.yangcentral.yangkit.common.api.exception.ErrorTag;
-import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.Status;
 import org.yangcentral.yangkit.model.api.stmt.StatusStmt;
-import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.util.ModelUtil;
 
 public class StatusImpl extends YangSimpleStatementImpl implements StatusStmt {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/SubModuleImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/SubModuleImpl.java
@@ -58,7 +58,7 @@ public class SubModuleImpl extends ModuleImpl implements SubModule {
    }
 
    public List<YangStatement> getEffectiveLinkageStatement() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(super.getEffectiveLinkageStatement());
       if (this.belongsTo != null) {
          statements.add(this.belongsTo);

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/TypeImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/TypeImpl.java
@@ -52,7 +52,6 @@ import org.yangcentral.yangkit.model.impl.restriction.YangStringImpl;
 import org.yangcentral.yangkit.util.ModelUtil;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -92,32 +91,30 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
    private ValidatorResult buildBits(BitsImpl bits) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       boolean find = false;
-      Iterator<YangElement> elementIterator = this.getSubElements().iterator();
-      while (elementIterator.hasNext()){
-         YangElement subElement = elementIterator.next();
-         if(!(subElement instanceof YangBuiltinStatement)){
+      for (YangElement subElement : this.getSubElements()) {
+         if (!(subElement instanceof YangBuiltinStatement)) {
             continue;
          }
-         YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+         YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
          if (!builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.BIT.getQName())) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             continue;
          }
          Bit bit = (Bit) builtinStatement;
          find = true;
-         if(isDerivedType()){
+         if (isDerivedType()) {
             String yangVersion = this.getContext().getCurModule().getEffectiveYangVersion();
             if (!yangVersion.equals(Yang.VERSION_11)) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNEXPECTED_IDENTIFIER.getFieldName() + " Derived bits can not be restricted."));
+                   ErrorCode.UNEXPECTED_IDENTIFIER.getFieldName() + " Derived bits can not be restricted."));
                continue;
             }
-            Bits base = (Bits)this.getBaseType();
-            Map<String, Bit> baseBitMap = (Map)base.getBits().stream().collect(Collectors.toMap(YangStatement::getArgStr, YangStatement::getSelf));
+            Bits base = (Bits) this.getBaseType();
+            Map<String, Bit> baseBitMap = base.getBits().stream().collect(Collectors.toMap(YangStatement::getArgStr, YangStatement::getSelf));
             if (!baseBitMap.containsKey(bit.getArgStr())) {
-              validatorResultBuilder.addRecord(ModelUtil.reportError(bit,
-                       ErrorCode.UNEXPECTED_IDENTIFIER.getFieldName() + " It should be in base-type's bit set." ));
+               validatorResultBuilder.addRecord(ModelUtil.reportError(bit,
+                   ErrorCode.UNEXPECTED_IDENTIFIER.getFieldName() + " It should be in base-type's bit set."));
                continue;
             }
 
@@ -125,21 +122,21 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
                Long baseActualPosition = base.getBitActualPosition(bit.getArgStr());
                if (bit.getPosition().getValue() != baseActualPosition) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                          ErrorCode.INVALID_SUBSTATEMENT.getFieldName() + " The bit's position MUST not be changed." ));
+                      ErrorCode.INVALID_SUBSTATEMENT.getFieldName() + " The bit's position MUST not be changed."));
                   continue;
                }
             }
          } else {
             if (bits.getBits().size() > 0 && bits.getMaxPosition() == Bits.MAX_POSITION && bit.getPosition() == null) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.BIT_NO_POSITION.getFieldName() ));
+                   ErrorCode.BIT_NO_POSITION.getFieldName()));
                continue;
             }
          }
-         boolean bool = bits.addBit((Bit)builtinStatement);
+         boolean bool = bits.addBit((Bit) builtinStatement);
          if (!bool) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+                ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
             continue;
          }
 
@@ -156,21 +153,19 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
    private ValidatorResult buildBinary(BinaryImpl binary) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       boolean find = false;
-      Iterator elementIterator = this.getSubElements().iterator();
       binary.setLength(null);
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             if (!builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.LENGTH.getQName())) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                   ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             } else if (find) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+                   ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
             } else {
                find = true;
-               binary.setLength((Length)builtinStatement);
+               binary.setLength((Length) builtinStatement);
             }
          }
       }
@@ -180,14 +175,12 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
 
    private ValidatorResult buildBoolean(YangBooleanImpl aBoolean) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator elementIterator = this.getSubElements().iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
          }
       }
 
@@ -198,33 +191,31 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       boolean findfractionDigits = false;
       boolean findRange = false;
-      Iterator elementIterator = this.getSubElements().iterator();
       decimal64.setFractionDigits(null);
       decimal64.setRange(null);
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             if (builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.FRACTIONDIGITS.getQName())) {
                if (findfractionDigits) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                          ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+                      ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
                } else {
                   findfractionDigits = true;
-                  decimal64.setFractionDigits((FractionDigits)builtinStatement);
+                  decimal64.setFractionDigits((FractionDigits) builtinStatement);
                }
             } else if (builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.RANGE.getQName())) {
                if (findRange) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                          ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+                      ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
                } else {
                   findRange = true;
-                  decimal64.setRange((Range)builtinStatement);
+                  decimal64.setRange((Range) builtinStatement);
                }
             } else {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                   ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             }
          }
       }
@@ -241,14 +232,12 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
 
    private ValidatorResult buildEmpty(EmptyImpl empty) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator elementIterator = this.getSubElements().iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
          }
       }
 
@@ -258,35 +247,33 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
    private ValidatorResult buildEnumeration(EnumerationImpl enumeration) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       boolean find = false;
-      Iterator<YangElement> elementIterator = this.getSubElements().iterator();
 
-      while (elementIterator.hasNext()){
-         YangElement subElement = elementIterator.next();
-         if(!(subElement instanceof YangBuiltinStatement)){
+      for (YangElement subElement : this.getSubElements()) {
+         if (!(subElement instanceof YangBuiltinStatement)) {
             continue;
          }
-         YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+         YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
          if (!builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.ENUM.getQName())) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             continue;
          }
 
-         YangEnum yangEnum = (YangEnum)builtinStatement;
+         YangEnum yangEnum = (YangEnum) builtinStatement;
          find = true;
          if (this.isDerivedType()) {
             String yangVersion = this.getContext().getCurModule().getEffectiveYangVersion();
             if (!yangVersion.equals(Yang.VERSION_11)) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNEXPECTED_IDENTIFIER.getFieldName() + " Derived enumeration can not be restricted."));
+                   ErrorCode.UNEXPECTED_IDENTIFIER.getFieldName() + " Derived enumeration can not be restricted."));
                continue;
             }
 
-            Enumeration base = (Enumeration)(this.getBaseType().getRestriction());
-            Map<String, YangEnum> baseYangEnumMap = (Map)base.getEnums().stream().collect(Collectors.toMap(YangStatement::getArgStr, YangStatement::getSelf));
+            Enumeration base = (Enumeration) (this.getBaseType().getRestriction());
+            Map<String, YangEnum> baseYangEnumMap = base.getEnums().stream().collect(Collectors.toMap(YangStatement::getArgStr, YangStatement::getSelf));
             if (!baseYangEnumMap.containsKey(builtinStatement.getArgStr())) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNEXPECTED_IDENTIFIER.getFieldName() + " It should be in base-type's enum set."));
+                   ErrorCode.UNEXPECTED_IDENTIFIER.getFieldName() + " It should be in base-type's enum set."));
                continue;
             }
 
@@ -294,20 +281,20 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
                Integer baseActualValue = base.getEnumActualValue(yangEnum.getArgStr());
                if (yangEnum.getValue().getValue() != baseActualValue) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                          ErrorCode.INVALID_SUBSTATEMENT.getFieldName() + " The enum's value MUST not be changed." ));
+                      ErrorCode.INVALID_SUBSTATEMENT.getFieldName() + " The enum's value MUST not be changed."));
                   continue;
                }
             }
          } else if (enumeration.getEnums().size() > 0 && enumeration.getHighestValue() == Enumeration.MAX_VALUE && yangEnum.getValue() == null) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.ENUM_NO_VALUE.getFieldName()));
+                ErrorCode.ENUM_NO_VALUE.getFieldName()));
             continue;
          }
 
-         boolean bool = enumeration.addEnum((YangEnum)builtinStatement);
+         boolean bool = enumeration.addEnum((YangEnum) builtinStatement);
          if (!bool) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+                ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
             continue;
          }
 
@@ -324,37 +311,35 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
    private ValidatorResult buildIdentityRef(IdentityRefImpl identityRef) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       boolean find = false;
-      Iterator<YangElement> elementIterator = this.getSubElements().iterator();
-      while (elementIterator.hasNext()){
-         YangElement subElement = elementIterator.next();
-         if(!(subElement instanceof YangBuiltinStatement)){
+      for (YangElement subElement : this.getSubElements()) {
+         if (!(subElement instanceof YangBuiltinStatement)) {
             continue;
          }
-         YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+         YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
          ValidatorRecordBuilder validatorRecordBuilder;
          if (this.isDerivedType()) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.IDENTITYREF_CANNOT_RESTRICTED.getFieldName()));
+                ErrorCode.IDENTITYREF_CANNOT_RESTRICTED.getFieldName()));
             continue;
          }
 
          if (!builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.BASE.getQName())) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             continue;
          }
          find = true;
-         Base newBase = (Base)builtinStatement;
+         Base newBase = (Base) builtinStatement;
          if (identityRef.getBases().size() > 0 && this.getContext().getCurModule().getEffectiveYangVersion().equals(Yang.VERSION_1)) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.CARDINALITY_BROKEN.getFieldName()));
+                ErrorCode.CARDINALITY_BROKEN.getFieldName()));
             continue;
          }
 
          boolean bool = identityRef.addBase(newBase);
          if (!bool) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+                ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
             continue;
          }
       }
@@ -370,25 +355,23 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
    private ValidatorResult buildInstanceIdentifier(InstanceIdentifierImpl instanceIdentifier) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       instanceIdentifier.setRequireInstance(null);
-      Iterator<YangElement> elementIterator = this.getSubElements().iterator();
-      while (elementIterator.hasNext()){
-         YangElement subElement = elementIterator.next();
-         if(!(subElement instanceof YangBuiltinStatement)){
+      for (YangElement subElement : this.getSubElements()) {
+         if (!(subElement instanceof YangBuiltinStatement)) {
             continue;
          }
-         YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+         YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
          if (!builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.REQUIREINSTANCE.getQName())) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             continue;
          }
-         RequireInstance newRequireInstance = (RequireInstance)builtinStatement;
+         RequireInstance newRequireInstance = (RequireInstance) builtinStatement;
          if (this.isDerivedType()) {
-            InstanceIdentifier baseInstanceIdentifier = (InstanceIdentifier)this.getBaseType().getRestriction();
+            InstanceIdentifier baseInstanceIdentifier = (InstanceIdentifier) this.getBaseType().getRestriction();
             if (baseInstanceIdentifier.isRequireInstance() && !newRequireInstance.value()) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getSeverity(),ErrorTag.BAD_ELEMENT,
-                       ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getFieldName()));
+                   ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getSeverity(), ErrorTag.BAD_ELEMENT,
+                   ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getFieldName()));
                if (ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getSeverity() == Severity.ERROR) {
                   continue;
                }
@@ -403,17 +386,15 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
 
    private ValidatorResult buildYangInteger(YangIntegerImpl integer) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator elementIterator = this.getSubElements().iterator();
       integer.setRange(null);
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             if (!builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.RANGE.getQName())) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                   ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             } else {
-               Range newRange = (Range)builtinStatement;
+               Range newRange = (Range) builtinStatement;
                validatorResultBuilder.merge(integer.setRange(newRange));
             }
          }
@@ -424,18 +405,16 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
 
    private ValidatorResult buildLeafRef(LeafRefImpl leafRef) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator<YangElement> elementIterator = this.getSubElements().iterator();
-      while (elementIterator.hasNext()){
-         YangElement subElement = elementIterator.next();
-         if(!(subElement instanceof YangBuiltinStatement)){
+      for (YangElement subElement : this.getSubElements()) {
+         if (!(subElement instanceof YangBuiltinStatement)) {
             continue;
          }
-         YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+         YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
          ValidatorRecordBuilder validatorRecordBuilder;
          if (builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.REQUIREINSTANCE.getQName())) {
             if (this.getContext().getCurModule().getYangVersion().equals(Yang.VERSION_1)) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                   ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
                continue;
             }
 
@@ -444,8 +423,8 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
                LeafRef baseLeafref = (LeafRef) this.getBaseType().getRestriction();
                if (baseLeafref.isRequireInstance() && !newRequireInstance.value()) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                          ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getSeverity(),ErrorTag.BAD_ELEMENT,
-                          ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getFieldName()));
+                      ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getSeverity(), ErrorTag.BAD_ELEMENT,
+                      ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getFieldName()));
                   if (ErrorCode.DERIVEDTYPE_EXPAND_VALUESPACE.getSeverity() == Severity.ERROR) {
                      continue;
                   }
@@ -453,7 +432,7 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
             }
             leafRef.setRequireInstance(newRequireInstance);
          } else if (builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.PATH.getQName())) {
-            Path newPath = (Path)builtinStatement;
+            Path newPath = (Path) builtinStatement;
             if (this.isDerivedType()) {
                validatorRecordBuilder = new ValidatorRecordBuilder();
                validatorRecordBuilder.setErrorTag(ErrorTag.BAD_ELEMENT);
@@ -462,7 +441,7 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
                validatorRecordBuilder.setBadElement(builtinStatement);
                validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.LEAFREF_CANNOT_RESTRICTED_BY_PATH.getFieldName()));
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.LEAFREF_CANNOT_RESTRICTED_BY_PATH.getFieldName()));
+                   ErrorCode.LEAFREF_CANNOT_RESTRICTED_BY_PATH.getFieldName()));
                continue;
             }
             leafRef.setPath(newPath);
@@ -474,7 +453,7 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
             validatorRecordBuilder.setBadElement(builtinStatement);
             validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                    ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             continue;
          }
       }
@@ -483,30 +462,28 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
 
    private ValidatorResult buildYangString(YangStringImpl string) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator elementIterator = this.getSubElements().iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
-            YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+            YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             if (builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.LENGTH.getQName())) {
-               Length newLength = (Length)builtinStatement;
+               Length newLength = (Length) builtinStatement;
                if (string.getLength() != null) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                          ErrorCode.CARDINALITY_BROKEN.getFieldName()));
+                      ErrorCode.CARDINALITY_BROKEN.getFieldName()));
                } else {
                   validatorResultBuilder.merge(string.setLength(newLength));
                }
             } else if (builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.PATTERN.getQName())) {
-               Pattern pattern = (Pattern)builtinStatement;
+               Pattern pattern = (Pattern) builtinStatement;
                boolean bool = string.addPattern(pattern);
                if (!bool) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                          ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+                      ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
                }
             } else {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName() ));
+                   ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
             }
          }
       }
@@ -516,25 +493,23 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
 
    private ValidatorResult buildUnion(UnionImpl union) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator elementIterator = this.getSubElements().iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.getSubElements()) {
          if (subElement instanceof YangBuiltinStatement) {
             YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
             if (this.isDerivedType()) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                       ErrorCode.UNION_CANNOT_RESTRICTED.getFieldName()));
+                   ErrorCode.UNION_CANNOT_RESTRICTED.getFieldName()));
             } else {
                if (!builtinStatement.getYangKeyword().equals(YangBuiltinKeyword.TYPE.getQName())) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                          ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
+                      ErrorCode.UNRECOGNIZED_KEYWORD.getFieldName()));
                } else {
-                  Type newType = (Type)builtinStatement;
+                  Type newType = (Type) builtinStatement;
                   boolean bool = union.addType(newType);
                   if (!bool) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(builtinStatement,
-                             ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
+                         ErrorCode.DUPLICATE_DEFINITION.getFieldName()));
                   }
                }
             }
@@ -724,17 +699,15 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
    }
 
    public static List<Typedef> getAllDerived(Type type) {
-      List<Typedef> typedefs = new ArrayList();
+      List<Typedef> typedefs = new ArrayList<>();
       if (type.isDerivedType()) {
          typedefs.add(type.getDerived());
          Typedef derived = type.getDerived();
          typedefs.addAll(getAllDerived(derived.getType()));
       } else if (type.getRestriction() instanceof Union) {
          Union union = (Union)type.getRestriction();
-         Iterator typeIterator = union.getTypes().iterator();
 
-         while(typeIterator.hasNext()) {
-            Type subtype = (Type)typeIterator.next();
+         for (Type subtype : union.getTypes()) {
             typedefs.addAll(getAllDerived(subtype));
          }
       }
@@ -763,10 +736,8 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
                   lastResult = false;
                } else {
                   List<Typedef> typedefs = getAllDerived(this);
-                  Iterator typedefIterator = typedefs.iterator();
 
-                  while(typedefIterator.hasNext()) {
-                     Typedef typedef = (Typedef)typedefIterator.next();
+                  for (Typedef typedef : typedefs) {
                      typedef.addReference(this);
                   }
                }
@@ -787,7 +758,7 @@ public class TypeImpl extends YangBuiltInStatementImpl implements Type {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.restriction instanceof YangInteger) {
          YangInteger yangInteger = (YangInteger)this.restriction;
          if (yangInteger.getEffectiveRange() != null) {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/TypedDataNodeImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/TypedDataNodeImpl.java
@@ -136,7 +136,7 @@ public abstract class TypedDataNodeImpl extends DataNodeImpl implements TypedDat
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.type != null) {
          statements.add(this.type);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/TypedefContainerImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/TypedefContainerImpl.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TypedefContainerImpl implements TypedefContainer {
-   private List<Typedef> typedefs = new ArrayList();
+   private List<Typedef> typedefs = new ArrayList<>();
    private YangContext yangContext;
 
    public YangContext getYangContext() {
@@ -27,7 +27,7 @@ public class TypedefContainerImpl implements TypedefContainer {
    }
 
    public Typedef getTypedef(int index) {
-      return (Typedef)this.typedefs.get(index);
+      return this.typedefs.get(index);
    }
 
    public ValidatorResult addTypedef(Typedef typedef) {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/TypedefImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/TypedefImpl.java
@@ -20,7 +20,7 @@ public class TypedefImpl extends EntityImpl implements Typedef {
    private Type type;
    private Units units;
    private Default aDefault;
-   private List<YangStatement> referencedBys = new ArrayList();
+   private List<YangStatement> referencedBys = new ArrayList<>();
 
    public TypedefImpl(String argStr) {
       super(argStr);
@@ -92,7 +92,7 @@ public class TypedefImpl extends EntityImpl implements Typedef {
 
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.type != null) {
          statements.add(this.type);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/UniqueImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/UniqueImpl.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class UniqueImpl extends YangBuiltInStatementImpl implements Unique {
-   private List<Leaf> uniqueNodes = new ArrayList();
+   private List<Leaf> uniqueNodes = new ArrayList<>();
 
    public UniqueImpl(String argStr) {
       super(argStr);
@@ -22,7 +22,7 @@ public class UniqueImpl extends YangBuiltInStatementImpl implements Unique {
    }
 
    public boolean addUniqueNode(Leaf uniqueNode) {
-      Iterator iterator = this.uniqueNodes.iterator();
+      Iterator<Leaf> iterator = this.uniqueNodes.iterator();
 
       Leaf uni;
       do {
@@ -30,7 +30,7 @@ public class UniqueImpl extends YangBuiltInStatementImpl implements Unique {
             return this.uniqueNodes.add(uniqueNode);
          }
 
-         uni = (Leaf)iterator.next();
+         uni = iterator.next();
       } while(!uni.getArgStr().equals(uniqueNode.getArgStr()));
 
       return false;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/UsesImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/UsesImpl.java
@@ -36,15 +36,14 @@ import org.yangcentral.yangkit.util.ModelUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
 public class UsesImpl extends DataDefinitionImpl implements Uses {
    private Grouping refGrouping;
-   private List<Augment> augments = new ArrayList();
-   private List<Refine> refines = new ArrayList();
-   private SchemaNodeContainerImpl schemaNodeContainer = new SchemaNodeContainerImpl(this);
+   private final List<Augment> augments = new ArrayList<>();
+   private final List<Refine> refines = new ArrayList<>();
+   private final SchemaNodeContainerImpl schemaNodeContainer = new SchemaNodeContainerImpl(this);
 
    public UsesImpl(String argStr) {
       super(argStr);
@@ -85,13 +84,8 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
       validatorResultBuilder.merge(super.initSelf());
 
       List<YangStatement> matched = this.getSubStatement(YangBuiltinKeyword.AUGMENT.getQName());
-      Iterator iterator;
-      YangStatement child;
       if (matched.size() > 0) {
-         iterator = matched.iterator();
-
-         while(iterator.hasNext()) {
-            child = (YangStatement)iterator.next();
+         for (YangStatement child : matched) {
             Augment augment = (Augment)child;
             this.augments.add(augment);
          }
@@ -99,10 +93,7 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
 
       matched = this.getSubStatement(YangBuiltinKeyword.REFINE.getQName());
       if (matched.size() > 0) {
-         iterator = matched.iterator();
-
-         while(iterator.hasNext()) {
-            child = (YangStatement)iterator.next();
+         for (YangStatement child : matched) {
             Refine refine = (Refine)child;
             this.refines.add(refine);
          }
@@ -128,9 +119,9 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
             validatorRecordBuilder.setSeverity(Severity.ERROR);
             validatorRecordBuilder.setErrorPath(this.getElementPosition());
             validatorRecordBuilder.setErrorTag(ErrorTag.BAD_ELEMENT);
-            validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.MISSING_DEPENDENCE_MODULE.toString(new String[]{"name=" + ((ModuleId) moduleIdOp.get()).getModuleName()})));
+            validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.MISSING_DEPENDENCE_MODULE.toString(new String[]{"name=" + moduleIdOp.get().getModuleName()})));
             validatorResultBuilder.addRecord(ModelUtil.reportError(this,
-                    ErrorCode.MISSING_DEPENDENCE_MODULE.toString(new String[]{"name=" + ((ModuleId) moduleIdOp.get()).getModuleName()}) ));
+                    ErrorCode.MISSING_DEPENDENCE_MODULE.toString(new String[]{"name=" + moduleIdOp.get().getModuleName()}) ));
             return null;
          }
          Module targetModule = moduleOptional.get();
@@ -189,20 +180,18 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
 
             //build datadef
             List<DataDefinition> dataDefChildren = this.refGrouping.getDataDefChildren();
-            Iterator<DataDefinition> dataDefinitionIterator = dataDefChildren.iterator();
-            while(dataDefinitionIterator.hasNext()) {
-               DataDefinition dataDefinition = dataDefinitionIterator.next();
-               DataDefinition clonedDataDefiniton = (DataDefinition)dataDefinition.clone();
+            for (DataDefinition dataDefinition : dataDefChildren) {
+               DataDefinition clonedDataDefiniton = (DataDefinition) dataDefinition.clone();
                YangContext newYangContext = dataDefinition.getContext().clone();
                newYangContext.setCurGrouping(this.getContext().getCurGrouping());
                clonedDataDefiniton.setContext(newYangContext);
                clonedDataDefiniton.getContext().setNamespace(this.getContext().getNamespace());
                clonedDataDefiniton.init();
-               for(BuildPhase buildPhase:BuildPhase.values()) {
+               for (BuildPhase buildPhase : BuildPhase.values()) {
                   if (buildPhase.compareTo(phase) <= 0) {
                      ValidatorResult phaseResult = clonedDataDefiniton.build(buildPhase);
                      validatorResultBuilder.merge(phaseResult);
-                     if(!phaseResult.isOk()){
+                     if (!phaseResult.isOk()) {
                         break;
                      }
                   }
@@ -212,17 +201,15 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
                validatorResultBuilder.merge(this.addSchemaNodeChild(clonedDataDefiniton));
             }
             //build action
-            Iterator<Action> actionIterator = this.refGrouping.getActions().iterator();
-            while(actionIterator.hasNext()) {
-               Action action = actionIterator.next();
-               Action clonedAction = (Action)action.clone();
+            for (Action action : this.refGrouping.getActions()) {
+               Action clonedAction = (Action) action.clone();
                clonedAction.setContext(action.getContext().clone());
                clonedAction.getContext().setNamespace(this.getContext().getNamespace());
                clonedAction.getContext().setCurGrouping(this.getContext().getCurGrouping());
                clonedAction.init();
 
 
-               for(BuildPhase buildPhase:BuildPhase.values()) {
+               for (BuildPhase buildPhase : BuildPhase.values()) {
                   if (buildPhase.compareTo(phase) < 0) {
                      clonedAction.build(buildPhase);
                   }
@@ -232,16 +219,13 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
                validatorResultBuilder.merge(this.addSchemaNodeChild(clonedAction));
             }
 
-            Iterator<Notification> notificationIterator = this.refGrouping.getNotifications().iterator();
-
-            while(notificationIterator.hasNext()) {
-               Notification notification = notificationIterator.next();
-               Notification clonedNotification = (Notification)notification.clone();
+            for (Notification notification : this.refGrouping.getNotifications()) {
+               Notification clonedNotification = (Notification) notification.clone();
                clonedNotification.setContext(notification.getContext().clone());
                clonedNotification.getContext().setNamespace(this.getContext().getNamespace());
                clonedNotification.getContext().setCurGrouping(this.getContext().getCurGrouping());
                clonedNotification.init();
-               for(BuildPhase buildPhase:BuildPhase.values()) {
+               for (BuildPhase buildPhase : BuildPhase.values()) {
                   if (buildPhase.compareTo(phase) < 0) {
                      clonedNotification.build(buildPhase);
                   }
@@ -251,50 +235,44 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
                validatorResultBuilder.merge(this.addSchemaNodeChild(clonedNotification));
             }
             //build augments
-            Iterator<Augment> augmentIterator = this.augments.iterator();
-            while(augmentIterator.hasNext()) {
-               Augment augment = augmentIterator.next();
+            for (Augment augment : this.augments) {
                augment.setTargetPath(null);
                try {
                   SchemaPath targetPath = SchemaPathImpl.from(
-                          this, augment,augment.getArgStr());
+                      this, augment, augment.getArgStr());
                   augment.setTargetPath(targetPath);
                   SchemaNode target = targetPath.getSchemaNode(this.getContext().getSchemaContext());
-                  if(target == null){
+                  if (target == null) {
                      continue;
                   }
                   if (!(target instanceof Augmentable)) {
                      validatorResultBuilder.addRecord(ModelUtil.reportError(augment,
-                             ErrorCode.TARGET_CAN_NOT_AUGMENTED.getFieldName()));
+                         ErrorCode.TARGET_CAN_NOT_AUGMENTED.getFieldName()));
                      continue;
                   }
                   augment.setTarget(target);
-                  SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer)target;
+                  SchemaNodeContainer schemaNodeContainer = (SchemaNodeContainer) target;
                   validatorResultBuilder.merge(schemaNodeContainer.addSchemaNodeChild(augment));
                } catch (ModelException e) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(augment,e.getSeverity(),
-                          ErrorTag.BAD_ELEMENT,e.getDescription()));
+                  validatorResultBuilder.addRecord(ModelUtil.reportError(augment, e.getSeverity(),
+                      ErrorTag.BAD_ELEMENT, e.getDescription()));
                   continue;
                }
             }
 
-
-            Iterator<Refine> refineIterator = this.refines.iterator();
-
-            while(refineIterator.hasNext()) {
-               Refine refine = refineIterator.next();
+            for (Refine refine : this.refines) {
                //refine.setTargetPath(null);
                try {
-                  SchemaPath targetPath = SchemaPathImpl.from( this, refine,refine.getArgStr());
+                  SchemaPath targetPath = SchemaPathImpl.from(this, refine, refine.getArgStr());
                   refine.setTargetPath(targetPath);
                   SchemaNode target = targetPath.getSchemaNode(this.getContext().getSchemaContext());
-                  if(null == target){
+                  if (null == target) {
                      continue;
                   }
                   refine.setTarget(target);
                } catch (ModelException e) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError(refine,e.getSeverity(),
-                          ErrorTag.BAD_ELEMENT,e.getDescription()));
+                  validatorResultBuilder.addRecord(ModelUtil.reportError(refine, e.getSeverity(),
+                      ErrorTag.BAD_ELEMENT, e.getDescription()));
                   continue;
                }
             }
@@ -302,10 +280,7 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
          }
 
          case SCHEMA_TREE:{
-            Iterator schemaNodeIterator = this.getSchemaNodeChildren().iterator();
-
-            while(schemaNodeIterator.hasNext()) {
-               SchemaNode child = (SchemaNode)schemaNodeIterator.next();
+            for (SchemaNode child : this.getSchemaNodeChildren()) {
                validatorResultBuilder.merge(child.build(phase));
             }
             break;
@@ -325,16 +300,14 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
          return false;
       } else {
          SchemaNodeContainer parent = this.getParentSchemaNode();
-         return parent instanceof SchemaNode ? ((SchemaNode)parent).isConfig() : true;
+         return !(parent instanceof SchemaNode) || ((SchemaNode) parent).isConfig();
       }
    }
 
    protected ValidatorResult validateSelf() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.validateSelf());
-      Iterator schemaNodeIterator = this.getSchemaNodeChildren().iterator();
 
-      while(schemaNodeIterator.hasNext()) {
-         SchemaNode child = (SchemaNode)schemaNodeIterator.next();
+      for (SchemaNode child : this.getSchemaNodeChildren()) {
          validatorResultBuilder.merge(child.validate());
       }
 
@@ -389,7 +362,7 @@ public class UsesImpl extends DataDefinitionImpl implements Uses {
       return this.schemaNodeContainer.getEffectiveSchemaNodeChildren(ignoreNamespace);
    }
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       statements.addAll(getEffectiveSchemaNodeChildren());
       statements.addAll(super.getEffectiveSubStatements());
       return statements;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/WhenImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/WhenImpl.java
@@ -93,7 +93,7 @@ public class WhenImpl extends YangBuiltInStatementImpl implements When {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.description != null) {
          statements.add(this.description);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YangBuiltInStatementImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YangBuiltInStatementImpl.java
@@ -2,7 +2,6 @@ package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.*;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.*;
@@ -10,7 +9,6 @@ import org.yangcentral.yangkit.register.YangUnknownParserPolicy;
 import org.yangcentral.yangkit.register.YangUnknownRegister;
 import org.yangcentral.yangkit.util.ModelUtil;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -45,37 +43,33 @@ public abstract class YangBuiltInStatementImpl extends YangStatementImpl {
 
 
       Map<QName, YangSubStatementInfo> subStatementInfos = statementDef.getSubStatementInfos();
-      Iterator<QName> keys = subStatementInfos.keySet().iterator();
 
-      while(keys.hasNext()) {
-         QName key = keys.next();
+      for (QName key : subStatementInfos.keySet()) {
          List<YangStatement> filteredStatements = this.getSubStatement(key);
          Cardinality cardinality = subStatementInfos.get(key).getCardinality();
          if (!cardinality.isValid(filteredStatements.size())) {
             validatorResultBuilder.addRecord(ModelUtil.reportError(this,
-                    ErrorCode.CARDINALITY_BROKEN.getFieldName() + " sub-statement:" + key.getLocalName() + "'s cardinality is:" + cardinality ));
+                ErrorCode.CARDINALITY_BROKEN.getFieldName() + " sub-statement:" + key.getLocalName() + "'s cardinality is:" + cardinality));
          }
       }
 
-      Iterator<YangElement> elementIterator = this.getSubElements().iterator();
-      while (elementIterator.hasNext()){
-         YangElement subElement = elementIterator.next();
-         if(!(subElement instanceof YangStatement)){
+      for (YangElement subElement : this.getSubElements()) {
+         if (!(subElement instanceof YangStatement)) {
             continue;
          }
          YangStatement yangStatement = (YangStatement) subElement;
          if (!subStatementInfos.containsKey(yangStatement.getYangKeyword())) {
             if (!(yangStatement instanceof YangUnknown)) {
                validatorResultBuilder.addRecord(ModelUtil.reportError(yangStatement,
-                       ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
+                   ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
             } else {
-               YangUnknownParserPolicy unknownParserPolicy = YangUnknownRegister.getInstance().getUnknownInfo(((YangUnknown)subElement).getYangKeyword());
+               YangUnknownParserPolicy unknownParserPolicy = YangUnknownRegister.getInstance().getUnknownInfo(((YangUnknown) subElement).getYangKeyword());
                if (unknownParserPolicy == null || unknownParserPolicy.getParentStatements().size() <= 0) {
                   continue;
                }
                if (unknownParserPolicy.getParentStatement(this.getYangKeyword()) == null) {
-                  validatorResultBuilder.addRecord(ModelUtil.reportError((YangStatement)subElement,
-                          ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
+                  validatorResultBuilder.addRecord(ModelUtil.reportError((YangStatement) subElement,
+                      ErrorCode.INVALID_SUBSTATEMENT.getFieldName()));
                }
             }
          }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YangStatementImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YangStatementImpl.java
@@ -5,7 +5,6 @@ import org.yangcentral.yangkit.common.api.Namespace;
 import org.yangcentral.yangkit.common.api.QName;
 import org.yangcentral.yangkit.common.api.exception.ErrorTag;
 import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.*;
@@ -22,8 +21,8 @@ public abstract class YangStatementImpl implements YangStatement {
    private YangContext context;
    private Position position;
    private String argStr;
-   private List<YangElement> subElements = new ArrayList();
-   private List<YangUnknown> unknowns = new ArrayList();
+   private final List<YangElement> subElements = new ArrayList<>();
+   private final List<YangUnknown> unknowns = new ArrayList<>();
    //protected boolean isBuilt;
    protected boolean isBuilding;
    //protected boolean isValidated;
@@ -35,7 +34,7 @@ public abstract class YangStatementImpl implements YangStatement {
    private ValidatorResult initResult;
    private int lastSeq =0;
    private int seq = 0;
-   private Map<BuildPhase, ValidatorResult> phaseResultMap = new ConcurrentHashMap();
+   private final Map<BuildPhase, ValidatorResult> phaseResultMap = new ConcurrentHashMap<>();
    private boolean isError = false;
    private YangStatement clonedBy;
    private boolean cleared = true;
@@ -104,12 +103,10 @@ public abstract class YangStatementImpl implements YangStatement {
 
    protected ValidatorResult afterValidateChildren() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator elementIterator = this.subElements.iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.subElements) {
          if (subElement instanceof YangStatement) {
-            YangStatement statement = (YangStatement)subElement;
+            YangStatement statement = (YangStatement) subElement;
             if (!statement.isErrorStatement()) {
                validatorResultBuilder.merge(statement.afterValidate());
             }
@@ -151,13 +148,11 @@ public abstract class YangStatementImpl implements YangStatement {
    }
 
    public List<YangStatement> getSubStatement(QName keyword) {
-      List<YangStatement> matched = new ArrayList();
-      Iterator yangElementIterator = this.subElements.iterator();
+      List<YangStatement> matched = new ArrayList<>();
 
-      while(yangElementIterator.hasNext()) {
-         YangElement element = (YangElement)yangElementIterator.next();
+      for (YangElement element : this.subElements) {
          if (element instanceof YangStatement) {
-            YangStatement subStatement = (YangStatement)element;
+            YangStatement subStatement = (YangStatement) element;
             if (subStatement.getYangKeyword().equals(keyword)) {
                matched.add(subStatement);
             }
@@ -220,11 +215,9 @@ public abstract class YangStatementImpl implements YangStatement {
    }
 
    private List<YangUnknown> getUnknowns(String keyword) {
-      List<YangUnknown> targetUnknowns = new ArrayList();
-      Iterator unknownIterator = this.unknowns.iterator();
+      List<YangUnknown> targetUnknowns = new ArrayList<>();
 
-      while(unknownIterator.hasNext()) {
-         YangUnknown unknown = (YangUnknown)unknownIterator.next();
+      for (YangUnknown unknown : this.unknowns) {
          if (unknown.getKeyword().equals(keyword)) {
             targetUnknowns.add(unknown);
          }
@@ -244,9 +237,7 @@ public abstract class YangStatementImpl implements YangStatement {
          }
       }
       if(this instanceof DefaultYangUnknown){
-         if(this.buildPhase == BuildPhase.SCHEMA_TREE && validatorResult.isOk()){
-            return true;
-         }
+         return this.buildPhase == BuildPhase.SCHEMA_TREE && validatorResult.isOk();
       }
       return false;
    }
@@ -282,15 +273,13 @@ public abstract class YangStatementImpl implements YangStatement {
 
    protected ValidatorResult validateChildren() {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator elementIterator = this.subElements.iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.subElements) {
          if (subElement instanceof YangStatement) {
-            YangStatement statement = (YangStatement)subElement;
+            YangStatement statement = (YangStatement) subElement;
             if (!statement.isErrorStatement()) {
-               if(statement instanceof SchemaNode && !((SchemaNode) statement).isActive()){
-                   continue;
+               if (statement instanceof SchemaNode && !((SchemaNode) statement).isActive()) {
+                  continue;
                }
                validatorResultBuilder.merge(statement.validate());
             }
@@ -427,22 +416,20 @@ public abstract class YangStatementImpl implements YangStatement {
    protected ValidatorResult buildChildren(BuildPhase phase) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
       List<YangUnknown> buildUnknowns = null;
-      Iterator elementIterator = this.subElements.iterator();
 
-      while(elementIterator.hasNext()) {
-         YangElement subElement = (YangElement)elementIterator.next();
+      for (YangElement subElement : this.subElements) {
          if (!(subElement instanceof YangComment)) {
             if (subElement instanceof YangUnknownBlock) {
                if (BuildPhase.GRAMMAR == phase) {
-                  YangUnknown unknown = ((YangUnknownBlock)subElement).build(this.getContext());
+                  YangUnknown unknown = ((YangUnknownBlock) subElement).build(this.getContext());
                   if (buildUnknowns == null) {
-                     buildUnknowns = new ArrayList();
+                     buildUnknowns = new ArrayList<>();
                   }
 
                   buildUnknowns.add(unknown);
                }
             } else {
-               YangStatement statement = (YangStatement)subElement;
+               YangStatement statement = (YangStatement) subElement;
                if (!statement.isErrorStatement()) {
                   validatorResultBuilder.merge(statement.build(phase));
                }
@@ -451,10 +438,8 @@ public abstract class YangStatementImpl implements YangStatement {
       }
 
       if (buildUnknowns != null) {
-         elementIterator = buildUnknowns.iterator();
 
-         while(elementIterator.hasNext()) {
-            YangUnknown yangUnknown = (YangUnknown)elementIterator.next();
+         for (YangUnknown yangUnknown : buildUnknowns) {
             this.addChild(yangUnknown);
             yangUnknown.setContext(new YangContext(this.getContext()));
             yangUnknown.init();
@@ -677,15 +662,11 @@ public abstract class YangStatementImpl implements YangStatement {
    public void setChildren(List<YangElement> yangElements) {
       this.subElements.clear();
       if (null != yangElements) {
-         Iterator elementIterator = yangElements.iterator();
-
-         while(elementIterator.hasNext()) {
-            YangElement yangElement = (YangElement)elementIterator.next();
+         for (YangElement yangElement : yangElements) {
             if (null != yangElement) {
                this.addChild(yangElement);
             }
          }
-
       }
    }
 
@@ -774,9 +755,7 @@ public abstract class YangStatementImpl implements YangStatement {
                  ErrorCode.INVALID_IDENTIFIER_REF.getFieldName() + " argument:" + this.getArgStr()));
       }
 
-      Iterator<YangElement> elementIterator = this.subElements.iterator();
-      while (elementIterator.hasNext()) {
-         YangElement subElement = elementIterator.next();
+      for (YangElement subElement : this.subElements) {
          if (!(subElement instanceof YangStatement)) {
             continue;
          }
@@ -857,18 +836,15 @@ public abstract class YangStatementImpl implements YangStatement {
          YangStatement clonedStatement = null;
          if (this instanceof YangUnknown) {
             constructor = this.getClass().getConstructor(String.class, String.class);
-            clonedStatement = (YangStatement)constructor.newInstance(((YangUnknown)this).getKeyword(), this.getArgStr());
+            clonedStatement = constructor.newInstance(((YangUnknown)this).getKeyword(), this.getArgStr());
          } else {
             constructor = this.getClass().getConstructor(String.class);
-            clonedStatement = (YangStatement)constructor.newInstance(this.getArgStr());
+            clonedStatement = constructor.newInstance(this.getArgStr());
          }
          //clonedStatement.setElementPosition(this.getElementPosition());
-         Iterator elementIterator = this.getSubElements().iterator();
-
-         while(elementIterator.hasNext()) {
-            YangElement subElement = (YangElement)elementIterator.next();
+         for (YangElement subElement : this.getSubElements()) {
             if (subElement instanceof YangStatement) {
-               YangStatement subStatement = (YangStatement)subElement;
+               YangStatement subStatement = (YangStatement) subElement;
                clonedStatement.addChild(subStatement.clone());
             }
          }
@@ -917,7 +893,7 @@ public abstract class YangStatementImpl implements YangStatement {
    }
 
    public int hashCode() {
-      return Objects.hash(new Object[]{this.getArgStr()});
+      return Objects.hash(this.getArgStr());
    }
 
    public boolean isErrorStatement() {
@@ -929,14 +905,7 @@ public abstract class YangStatementImpl implements YangStatement {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> subStatements = new ArrayList();
-      Iterator unknownIterator = this.unknowns.iterator();
-
-      while(unknownIterator.hasNext()) {
-         YangUnknown unknown = (YangUnknown)unknownIterator.next();
-         subStatements.add(unknown);
-      }
-
+      List<YangStatement> subStatements = new ArrayList<>(this.unknowns);
       return subStatements;
    }
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YangVersionImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YangVersionImpl.java
@@ -1,17 +1,11 @@
 package org.yangcentral.yangkit.model.impl.stmt;
 
 import org.yangcentral.yangkit.base.ErrorCode;
-import org.yangcentral.yangkit.base.Position;
 import org.yangcentral.yangkit.base.Yang;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.common.api.QName;
-import org.yangcentral.yangkit.common.api.exception.ErrorMessage;
-import org.yangcentral.yangkit.common.api.exception.ErrorTag;
-import org.yangcentral.yangkit.common.api.exception.Severity;
-import org.yangcentral.yangkit.common.api.validate.ValidatorRecordBuilder;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
-import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.model.api.stmt.YangVersion;
 import org.yangcentral.yangkit.util.ModelUtil;
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YinElementImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/YinElementImpl.java
@@ -35,10 +35,9 @@ public class YinElementImpl extends YangSimpleStatementImpl implements YinElemen
       if (!this.getArgStr().equals("true") && !this.getArgStr().equals("false")) {
          validatorResultBuilder.addRecord(ModelUtil.reportError(this,
                  ErrorCode.INVALID_ARG.getFieldName()));
-         return validatorResultBuilder.build();
       } else {
          this.value = Boolean.getBoolean(this.getArgStr());
-         return validatorResultBuilder.build();
       }
+      return validatorResultBuilder.build();
    }
 }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ext/AugmentStructureImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ext/AugmentStructureImpl.java
@@ -215,12 +215,10 @@ public class AugmentStructureImpl extends SchemaNodeImpl implements AugmentStruc
     protected ValidatorResult initSelf() {
         ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.initSelf());
         List<YangElement> subElements = this.getSubElements();
-        Iterator elementIterator = subElements.iterator();
 
-        while(elementIterator.hasNext()) {
-            YangElement subElement = (YangElement)elementIterator.next();
+        for (YangElement subElement : subElements) {
             if (subElement instanceof YangBuiltinStatement) {
-                YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+                YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
                 YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
                 switch (builtinKeyword) {
                     case CONTAINER:
@@ -232,7 +230,7 @@ public class AugmentStructureImpl extends SchemaNodeImpl implements AugmentStruc
                     case CHOICE:
                     case CASE:
                     case USES:
-                        DataDefinition newDataDefinition = (DataDefinition)builtinStatement;
+                        DataDefinition newDataDefinition = (DataDefinition) builtinStatement;
                         validatorResultBuilder.merge(this.addDataDefChild(newDataDefinition));
                         break;
                 }
@@ -244,7 +242,7 @@ public class AugmentStructureImpl extends SchemaNodeImpl implements AugmentStruc
 
     protected ValidatorResult buildSelf(BuildPhase phase) {
         ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder(super.buildSelf(phase));
-        Iterator iterator;
+        Iterator<SchemaNode> iterator;
         SchemaNode child;
         switch (phase) {
             case GRAMMAR:{
@@ -253,10 +251,8 @@ public class AugmentStructureImpl extends SchemaNodeImpl implements AugmentStruc
             }
             case SCHEMA_BUILD:{
                 List<DataDefinition> dataDefChildren = this.getDataDefChildren();
-                Iterator schemaChildrenIt = dataDefChildren.iterator();
 
-                while(schemaChildrenIt.hasNext()) {
-                    DataDefinition dataDefinition = (DataDefinition)schemaChildrenIt.next();
+                for (DataDefinition dataDefinition : dataDefChildren) {
                     validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
                 }
                 break;
@@ -283,7 +279,7 @@ public class AugmentStructureImpl extends SchemaNodeImpl implements AugmentStruc
                         this.setTarget(target);
                         iterator = this.getSchemaNodeChildren().iterator();
                         while(iterator.hasNext()) {
-                            child = (SchemaNode)iterator.next();
+                            child = iterator.next();
                             if (child instanceof DataDefinition) {
                                 if (!(this.target instanceof DataDefContainer)) {
                                     validatorResultBuilder.addRecord(
@@ -331,7 +327,7 @@ public class AugmentStructureImpl extends SchemaNodeImpl implements AugmentStruc
                 iterator = this.getSchemaNodeChildren().iterator();
 
                 while(iterator.hasNext()) {
-                    child = (SchemaNode)iterator.next();
+                    child = iterator.next();
                     if (child instanceof Case && ((Case)child).isShortCase()) {
                         validatorResultBuilder.merge(child.build(phase));
                     }
@@ -388,7 +384,7 @@ public class AugmentStructureImpl extends SchemaNodeImpl implements AugmentStruc
     }
 
     public List<YangStatement> getEffectiveSubStatements() {
-        List<YangStatement> statements = new ArrayList();
+        List<YangStatement> statements = new ArrayList<>();
         statements.addAll(getEffectiveSchemaNodeChildren());
         statements.addAll(super.getEffectiveSubStatements());
         return statements;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ext/YangDataImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ext/YangDataImpl.java
@@ -11,7 +11,6 @@ import org.yangcentral.yangkit.model.impl.stmt.DataDefContainerImpl;
 import org.yangcentral.yangkit.model.impl.stmt.SchemaNodeContainerImpl;
 import org.yangcentral.yangkit.model.impl.stmt.YangStatementImpl;
 import org.yangcentral.yangkit.register.*;
-import org.yangcentral.yangkit.util.ModelUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -162,12 +161,10 @@ public class  YangDataImpl extends YangStatementImpl implements YangData  {
         validatorResultBuilder.merge(super.initSelf());
 
         List<YangElement> subElements = this.getSubElements();
-        Iterator iterator = subElements.iterator();
 
-        while(iterator.hasNext()) {
-            YangElement subElement = (YangElement)iterator.next();
+        for (YangElement subElement : subElements) {
             if (subElement instanceof YangBuiltinStatement) {
-                YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+                YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
                 YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
                 switch (builtinKeyword) {
                     case CONTAINER:
@@ -178,7 +175,7 @@ public class  YangDataImpl extends YangStatementImpl implements YangData  {
                     case ANYXML:
                     case CHOICE:
                     case USES:
-                        DataDefinition newDataDefinition = (DataDefinition)builtinStatement;
+                        DataDefinition newDataDefinition = (DataDefinition) builtinStatement;
                         validatorResultBuilder.merge(this.dataDefContainer.addDataDefChild(newDataDefinition));
                         break;
                 }
@@ -239,10 +236,8 @@ public class  YangDataImpl extends YangStatementImpl implements YangData  {
                 return validatorResultBuilder.build();
             }
             case SCHEMA_BUILD:
-                Iterator iterator = this.getDataDefChildren().iterator();
 
-                while(iterator.hasNext()) {
-                    DataDefinition dataDefinition = (DataDefinition)iterator.next();
+                for (DataDefinition dataDefinition : this.getDataDefChildren()) {
                     validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
                 }
 
@@ -252,7 +247,7 @@ public class  YangDataImpl extends YangStatementImpl implements YangData  {
     }
 
     public List<YangStatement> getEffectiveSubStatements() {
-        List<YangStatement> statements = new ArrayList();
+        List<YangStatement> statements = new ArrayList<>();
         statements.addAll(getEffectiveSchemaNodeChildren());
         statements.addAll(super.getEffectiveSubStatements());
         return statements;

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ext/YangDataStructureChecker.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ext/YangDataStructureChecker.java
@@ -6,15 +6,10 @@ import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.Module;
 import org.yangcentral.yangkit.model.api.stmt.YangStatement;
-import org.yangcentral.yangkit.model.api.stmt.YangUnknown;
 import org.yangcentral.yangkit.model.api.stmt.ext.YangDataStructure;
 import org.yangcentral.yangkit.base.YangStatementChecker;
 import org.yangcentral.yangkit.util.ModelUtil;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 /**
  * 功能描述
@@ -51,4 +46,3 @@ public class YangDataStructureChecker implements YangStatementChecker {
         return validatorResultBuilder.build();
     }
 }
-

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ext/YangDataStructureImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/ext/YangDataStructureImpl.java
@@ -264,12 +264,10 @@ public class YangDataStructureImpl extends SchemaNodeImpl implements YangDataStr
         validatorResultBuilder.merge(super.initSelf());
 
         List<YangElement> subElements = this.getSubElements();
-        Iterator iterator = subElements.iterator();
 
-        while(iterator.hasNext()) {
-            YangElement subElement = (YangElement)iterator.next();
+        for (YangElement subElement : subElements) {
             if (subElement instanceof YangBuiltinStatement) {
-                YangBuiltinStatement builtinStatement = (YangBuiltinStatement)subElement;
+                YangBuiltinStatement builtinStatement = (YangBuiltinStatement) subElement;
                 YangBuiltinKeyword builtinKeyword = YangBuiltinKeyword.from(builtinStatement.getYangKeyword());
                 switch (builtinKeyword) {
                     case CONTAINER:
@@ -280,18 +278,18 @@ public class YangDataStructureImpl extends SchemaNodeImpl implements YangDataStr
                     case ANYXML:
                     case CHOICE:
                     case USES:
-                        DataDefinition newDataDefinition = (DataDefinition)builtinStatement;
+                        DataDefinition newDataDefinition = (DataDefinition) builtinStatement;
                         validatorResultBuilder.merge(this.dataDefContainer.addDataDefChild(newDataDefinition));
                         break;
                     case TYPEDEF:
-                        Typedef newTypedef = (Typedef)builtinStatement;
+                        Typedef newTypedef = (Typedef) builtinStatement;
                         validatorResultBuilder.merge(this.typedefContainer.addTypedef(newTypedef));
                         break;
                     case GROUPING:
-                        Grouping newGrouping = (Grouping)builtinStatement;
+                        Grouping newGrouping = (Grouping) builtinStatement;
                         validatorResultBuilder.merge(this.groupingDefContainer.addGrouping(newGrouping));
                         break;
-                    case MUST:{
+                    case MUST: {
                         Must must = (Must) builtinStatement;
                         validatorResultBuilder.merge(addMust(must));
                         break;
@@ -308,10 +306,8 @@ public class YangDataStructureImpl extends SchemaNodeImpl implements YangDataStr
         validatorResultBuilder.merge(super.buildSelf(phase));
         switch (phase) {
             case SCHEMA_BUILD:
-                Iterator iterator = this.getDataDefChildren().iterator();
 
-                while(iterator.hasNext()) {
-                    DataDefinition dataDefinition = (DataDefinition)iterator.next();
+                for (DataDefinition dataDefinition : this.getDataDefChildren()) {
                     validatorResultBuilder.merge(this.addSchemaNodeChild(dataDefinition));
                 }
 
@@ -325,7 +321,7 @@ public class YangDataStructureImpl extends SchemaNodeImpl implements YangDataStr
     }
 
     public List<YangStatement> getEffectiveSubStatements() {
-        List<YangStatement> statements = new ArrayList();
+        List<YangStatement> statements = new ArrayList<>();
         statements.addAll(getEffectiveSchemaNodeChildren());
         statements.addAll(this.groupingDefContainer.getGroupings());
         statements.addAll(this.mustSupport.getMusts());

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/BitImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/BitImpl.java
@@ -89,7 +89,7 @@ public class BitImpl extends EntityImpl implements Bit {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.position != null) {
          statements.add(this.position);
       } else {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/EnumImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/EnumImpl.java
@@ -89,7 +89,7 @@ public class EnumImpl extends EntityImpl implements YangEnum {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.value != null) {
          statements.add(this.value);
       } else {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/FractionDigitsImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/FractionDigitsImpl.java
@@ -31,7 +31,7 @@ public class FractionDigitsImpl extends YangBuiltInStatementImpl implements Frac
       if (this.value >= 1 && this.value <= 18) {
          return validatorResultBuilder.build();
       } else {
-         ValidatorRecordBuilder<Position, YangStatement> validatorRecordBuilder = new ValidatorRecordBuilder();
+         ValidatorRecordBuilder<Position, YangStatement> validatorRecordBuilder = new ValidatorRecordBuilder<>();
          validatorRecordBuilder.setBadElement(this);
          validatorRecordBuilder.setErrorPath(this.getElementPosition());
          validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.FRACTIONDIGITS_ERROR.getFieldName()));

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/PathImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/PathImpl.java
@@ -8,13 +8,11 @@ import org.yangcentral.yangkit.common.api.validate.ValidatorResult;
 import org.yangcentral.yangkit.common.api.validate.ValidatorResultBuilder;
 import org.yangcentral.yangkit.model.api.stmt.Import;
 import org.yangcentral.yangkit.model.api.stmt.Module;
-import org.yangcentral.yangkit.model.api.stmt.When;
 import org.yangcentral.yangkit.model.api.stmt.type.Path;
 import org.yangcentral.yangkit.model.impl.stmt.YangBuiltInStatementImpl;
 import org.yangcentral.yangkit.util.ModelUtil;
 import org.yangcentral.yangkit.xpath.YangLocationPath;
 import org.yangcentral.yangkit.xpath.YangXPath;
-import org.yangcentral.yangkit.xpath.impl.XPathUtil;
 import org.yangcentral.yangkit.xpath.impl.YangXPathImpl;
 import org.yangcentral.yangkit.xpath.impl.YangXPathPrefixVisitor;
 

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/PatternImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/PatternImpl.java
@@ -132,7 +132,7 @@ public class PatternImpl extends YangBuiltInStatementImpl implements Pattern {
    }
 
    public List<YangStatement> getEffectiveSubStatements() {
-      List<YangStatement> statements = new ArrayList();
+      List<YangStatement> statements = new ArrayList<>();
       if (this.errorMessage != null) {
          statements.add(this.errorMessage);
       }

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/SectionExpressionImpl.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/model/impl/stmt/type/SectionExpressionImpl.java
@@ -25,7 +25,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
    private Reference reference;
    private Comparable highBound;
    private Comparable lowBound;
-   private List<Section> sections = new ArrayList();
+   private List<Section> sections = new ArrayList<>();
 
    public SectionExpressionImpl(String argStr) {
       super(argStr);
@@ -113,8 +113,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
       switch (phase) {
          case GRAMMAR:
             try {
-               List<Section> sections = this.parseRange(this.getArgStr());
-               this.sections = sections;
+               this.sections = this.parseRange(this.getArgStr());
                if (!this.checkSections()) {
                   validatorResultBuilder.addRecord(ModelUtil.reportError(this,
                           ErrorCode.SECTIONS_MUST_ASCEND_ORDER.getFieldName()));
@@ -190,7 +189,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
    }
 
    private List<Section> parseRange(String expression) {
-      List<Section> sections = new ArrayList();
+      List<Section> sections = new ArrayList<>();
       if (null == expression) {
          return sections;
       } else if (0 == expression.length()) {
@@ -207,7 +206,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
             if (null != strs[i]) {
                Section section = this.parseSectionExpression(strs[i].trim());
                int lastIndex = sections.size() - 1;
-               if (lastIndex >= 0 && ((Section)sections.get(lastIndex)).getMax().compareTo(section.getMin()) >= 0) {
+               if (lastIndex >= 0 && sections.get(lastIndex).getMax().compareTo(section.getMin()) >= 0) {
                   throw new IllegalArgumentException("the range argument is not ascend order.");
                }
 
@@ -220,7 +219,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
    }
 
    private boolean match(Section section, List<Section> derivedSections) {
-      Iterator sectionIterator = derivedSections.iterator();
+      Iterator<Section> sectionIterator = derivedSections.iterator();
 
       Section derivedSection;
       do {
@@ -228,14 +227,14 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
             return false;
          }
 
-         derivedSection = (Section)sectionIterator.next();
+         derivedSection = sectionIterator.next();
       } while(!section.isSubSection(derivedSection));
 
       return true;
    }
 
    private boolean match(List<Section> sections, List<Section> derivedSections) {
-      Iterator sectionIterator = sections.iterator();
+      Iterator<Section> sectionIterator = sections.iterator();
 
       Section section;
       do {
@@ -243,7 +242,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
             return true;
          }
 
-         section = (Section)sectionIterator.next();
+         section = sectionIterator.next();
       } while(this.match(section, derivedSections));
 
       return false;
@@ -258,7 +257,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
    }
 
    public boolean evaluate(Comparable val) {
-      Iterator sectionIterator = this.sections.iterator();
+      Iterator<Section> sectionIterator = this.sections.iterator();
 
       Section section;
       do {
@@ -266,7 +265,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
             return false;
          }
 
-         section = (Section)sectionIterator.next();
+         section = sectionIterator.next();
       } while(!section.evaluate(val));
 
       return true;
@@ -278,7 +277,7 @@ abstract class SectionExpressionImpl extends YangBuiltInStatementImpl implements
    }
 
    public Comparable<?> getMin() {
-      return ((Section)this.sections.get(0)).getMin();
+      return (this.sections.get(0)).getMin();
    }
 
    public boolean equals(Object obj) {

--- a/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/register/YangStatementImplRegister.java
+++ b/yangkit-model-impl/src/main/java/org/yangcentral/yangkit/register/YangStatementImplRegister.java
@@ -1,7 +1,6 @@
 package org.yangcentral.yangkit.register;
 
 import org.yangcentral.yangkit.base.BuildPhase;
-import org.yangcentral.yangkit.base.Yang;
 import org.yangcentral.yangkit.base.YangBuiltinKeyword;
 import org.yangcentral.yangkit.model.impl.schema.YangSchemaContextImpl;
 import org.yangcentral.yangkit.model.impl.stmt.*;
@@ -37,7 +36,7 @@ public class YangStatementImplRegister {
       YangStatementRegister.getInstance().register(YangBuiltinKeyword.CONTACT.getQName(), new YangStatementParserPolicy(YangBuiltinKeyword.CONTACT.getQName(), ContactImpl.class));
       YangStatementRegister.getInstance().register(YangBuiltinKeyword.REVISION.getQName(), new YangStatementParserPolicy(YangBuiltinKeyword.REVISION.getQName(), RevisionImpl.class));
       YangStatementRegister.getInstance().register(YangBuiltinKeyword.SUBMODULE.getQName(), new YangStatementParserPolicy(YangBuiltinKeyword.SUBMODULE.getQName(), SubModuleImpl.class, Arrays.asList(BuildPhase.GRAMMAR, BuildPhase.SCHEMA_BUILD, BuildPhase.SCHEMA_EXPAND, BuildPhase.SCHEMA_MODIFIER, BuildPhase.SCHEMA_TREE)));
-      YangStatementRegister.getInstance().register(YangBuiltinKeyword.BELONGSTO.getQName(), new YangStatementParserPolicy(YangBuiltinKeyword.BELONGSTO.getQName(), BelongsToImpl.class, new ArrayList(Arrays.asList(BuildPhase.LINKAGE))));
+      YangStatementRegister.getInstance().register(YangBuiltinKeyword.BELONGSTO.getQName(), new YangStatementParserPolicy(YangBuiltinKeyword.BELONGSTO.getQName(), BelongsToImpl.class, new ArrayList<>(Arrays.asList(BuildPhase.LINKAGE))));
       YangStatementRegister.getInstance().register(YangBuiltinKeyword.TYPEDEF.getQName(), new YangStatementParserPolicy(YangBuiltinKeyword.TYPEDEF.getQName(), TypedefImpl.class));
       YangStatementRegister.getInstance().register(YangBuiltinKeyword.TYPE.getQName(), new YangStatementParserPolicy(YangBuiltinKeyword.TYPE.getQName(), TypeImpl.class, Arrays.asList(BuildPhase.GRAMMAR)));
       YangStatementRegister.getInstance().register(YangBuiltinKeyword.CONTAINER.getQName(), new YangStatementParserPolicy(YangBuiltinKeyword.CONTAINER.getQName(), ContainerImpl.class, Arrays.asList(BuildPhase.GRAMMAR, BuildPhase.SCHEMA_BUILD, BuildPhase.SCHEMA_TREE)));

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/Capability.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/Capability.java
@@ -3,7 +3,7 @@ package org.yangcentral.yangkit.parser;
 import java.net.URI;
 
 public class Capability {
-   private URI uri;
+   final private URI uri;
 
    public Capability(URI uri) {
       this.uri = uri;

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/CapabilityParser.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/CapabilityParser.java
@@ -18,16 +18,14 @@ public class CapabilityParser {
    }
 
    List<Capability> parse() throws DocumentException {
-      List<Capability> capabilities = new ArrayList();
+      List<Capability> capabilities = new ArrayList<>();
       SAXReader reader = new SAXReader();
       Document capabilitiesDoc = reader.read(new File(this.capabilityFile));
       Element root = capabilitiesDoc.getRootElement();
       Element capabilitiesElement = root.element("capabilities");
-      Iterator var6 = capabilitiesElement.elements().iterator();
 
-      while(var6.hasNext()) {
-         Element capabilityElement = (Element)var6.next();
-         String text = capabilityElement.getTextTrim();
+      for (Element element: capabilitiesElement.elements()) {
+         String text = element.getTextTrim();
          if (text.contains("module=")) {
             ModuleSupportCapability capability = new ModuleSupportCapability(URI.create(text));
             capability.parse(text);

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/ModuleListType.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/ModuleListType.java
@@ -6,5 +6,5 @@ public enum ModuleListType {
    @SerializedName("yang-library")
    YANG_LIB,
    @SerializedName("capabilities")
-   CAPABILITIES;
+   CAPABILITIES,
 }

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/ModuleSupportCapability.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/ModuleSupportCapability.java
@@ -3,14 +3,13 @@ package org.yangcentral.yangkit.parser;
 import org.yangcentral.yangkit.model.api.schema.ModuleId;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class ModuleSupportCapability extends Capability {
    private String module;
    private String revision;
-   private List<String> features = new ArrayList();
-   private List<String> deviations = new ArrayList();
+   private List<String> features = new ArrayList<>();
+   private List<String> deviations = new ArrayList<>();
 
    public ModuleSupportCapability(URI uri) {
       super(uri);
@@ -43,7 +42,7 @@ public class ModuleSupportCapability extends Capability {
    public void addFeature(String feature) {
       if (null != feature) {
          if (null == this.features) {
-            this.features = new ArrayList();
+            this.features = new ArrayList<>();
          }
 
          if (!this.features.contains(feature)) {
@@ -63,7 +62,7 @@ public class ModuleSupportCapability extends Capability {
    public void addDeviation(String deviation) {
       if (null != deviation) {
          if (null == this.deviations) {
-            this.deviations = new ArrayList();
+            this.deviations = new ArrayList<>();
          }
 
          if (!this.deviations.contains(deviation)) {
@@ -78,7 +77,8 @@ public class ModuleSupportCapability extends Capability {
       sb.append("module=");
       sb.append(this.module);
       if (null != this.revision) {
-         sb.append("&revision=" + this.revision);
+         sb.append("&revision=");
+         sb.append(this.revision);
       }
 
       int size;
@@ -89,7 +89,7 @@ public class ModuleSupportCapability extends Capability {
          size = this.features.size();
 
          for(i = 0; i < size; ++i) {
-            deviation = (String)this.features.get(i);
+            deviation = this.features.get(i);
             sb.append(deviation);
             if (i != size - 1) {
                sb.append(",");
@@ -102,7 +102,7 @@ public class ModuleSupportCapability extends Capability {
          size = this.deviations.size();
 
          for(i = 0; i < size; ++i) {
-            deviation = (String)this.deviations.get(i);
+            deviation = this.deviations.get(i);
             sb.append(deviation);
             if (i != size - 1) {
                sb.append(",");
@@ -167,19 +167,14 @@ public class ModuleSupportCapability extends Capability {
    public boolean match(ModuleId moduleId) {
       if (this.getModule().equals(moduleId.getModuleName()) && this.getRevision().equals(moduleId.getRevision())) {
          return true;
-      } else {
-         if (this.deviations != null) {
-            Iterator var2 = this.deviations.iterator();
-
-            while(var2.hasNext()) {
-               String deviation = (String)var2.next();
-               if (deviation.equals(moduleId.getModuleName())) {
-                  return true;
-               }
+      }
+      if (this.deviations != null) {
+         for (String deviation: this.deviations) {
+            if (deviation.equals(moduleId.getModuleName())) {
+               return true;
             }
          }
-
-         return false;
       }
+      return false;
    }
 }

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangParser.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangParser.java
@@ -384,7 +384,7 @@ public class YangParser {
          int singleQuoteBeginPos = -1;
          int singleQuoteEndPos = -1;
          boolean plusFlag = false;
-         ArrayList<String> values = new ArrayList(1);
+         ArrayList<String> values = new ArrayList<>(1);
          int curPos = env.getCurPos();
 
          String str;
@@ -447,8 +447,8 @@ public class YangParser {
             } else {
                StringBuilder sb = new StringBuilder();
 
-               for(int i = 0; i < values.size(); ++i) {
-                  str = values.get(i);
+               for (String s : values) {
+                  str = s;
                   if (null != str) {
                      sb.append(str);
                   }
@@ -671,7 +671,7 @@ public class YangParser {
                      else {
 
                         if (null == elements) {
-                           elements = new ArrayList<YangElement>();
+                           elements = new ArrayList<>();
 
                         }
                         elements.add(comment);
@@ -703,7 +703,7 @@ public class YangParser {
                   else {
 
                      if (null == elements) {
-                        elements = new ArrayList<YangElement>();
+                        elements = new ArrayList<>();
 
                      }
                      elements.add(comment);

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangParserEnv.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangParserEnv.java
@@ -7,7 +7,7 @@ import java.util.Stack;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class YangParserEnv implements Cloneable {
-   private Stack<YangStatement> statements = new Stack();
+   private Stack<YangStatement> statements = new Stack<>();
    private String filename;
    private String yangStr;
    private ParseStatus status;
@@ -22,7 +22,7 @@ public class YangParserEnv implements Cloneable {
       this.curLine = 1;
       this.curColumn = 1;
       this.curPos = -1;
-      this.positionMap = new ConcurrentHashMap();
+      this.positionMap = new ConcurrentHashMap<>();
    }
 
    public String getYangStr() {

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangYinParser.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YangYinParser.java
@@ -17,7 +17,6 @@ import org.yangcentral.yangkit.utils.file.FileUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -35,14 +34,12 @@ public class YangYinParser {
    }
 
    private static List<File> getYangFiles(List<File> files) {
-      List<File> yangFiles = new ArrayList();
+      List<File> yangFiles = new ArrayList<>();
       if (null == files) {
          return yangFiles;
       }
-      Iterator fileIterator = files.iterator();
 
-      while(fileIterator.hasNext()) {
-         File file = (File)fileIterator.next();
+      for (File file : files) {
          yangFiles.addAll(getYangFiles(file));
       }
 
@@ -50,7 +47,7 @@ public class YangYinParser {
    }
 
    private static List<File> getYangFiles(File dir) {
-      List<File> yangFiles = new ArrayList();
+      List<File> yangFiles = new ArrayList<>();
       if (dir.isFile()) {
          if (dir.getName().endsWith(".yang") || dir.getName().endsWith(".yin")) {
             yangFiles.add(dir);
@@ -86,17 +83,12 @@ public class YangYinParser {
       YangSchemaContext schemaContext = parse(yangDir, capabilities);
       if (dependency != null) {
          YangSchemaContext dependencyContext = parse(dependency);
-         Iterator it = dependencyContext.getModules().iterator();
 
-         while(it.hasNext()) {
-            Module depModule = (Module)it.next();
+         for (Module depModule : dependencyContext.getModules()) {
             schemaContext.addImportOnlyModule(depModule);
          }
 
-         it = dependencyContext.getParseResult().entrySet().iterator();
-
-         while(it.hasNext()) {
-            Map.Entry<String, List<YangElement>> entry = (Map.Entry)it.next();
+         for (Map.Entry<String, List<YangElement>> entry: dependencyContext.getParseResult().entrySet()) {
             if (!schemaContext.getParseResult().containsKey(entry.getKey())) {
                schemaContext.getParseResult().put(entry.getKey(),entry.getValue());
             }
@@ -111,19 +103,13 @@ public class YangYinParser {
       if (capabilities != null) {
          CapabilityParser capabilityParser = new CapabilityParser(capabilities);
          List<Capability> capabilityList = capabilityParser.parse();
-         List<Module> unMatchedModules = new ArrayList();
+         List<Module> unMatchedModules = new ArrayList<>();
          ModuleSet moduleSet = new ModuleSet();
-         Iterator moduleIterator = schemaContext.getModules().iterator();
 
-         Module module;
-         while (moduleIterator.hasNext()) {
-            module = (Module) moduleIterator.next();
+         for (Module module : schemaContext.getModules()) {
             boolean match = false;
-            Iterator capabilityIterator = capabilityList.iterator();
 
-
-            while (capabilityIterator.hasNext()) {
-               Capability capability = (Capability) capabilityIterator.next();
+            for (Capability capability : capabilityList) {
                if (!(capability instanceof ModuleSupportCapability)) {
                   continue;
                }
@@ -152,7 +138,7 @@ public class YangYinParser {
 
                if (module instanceof SubModule) {
                   SubModule subModule = (SubModule) module;
-                  YangStatement belongsTo = (YangStatement) subModule.getSubStatement(YangBuiltinKeyword.BELONGSTO.getQName()).get(0);
+                  YangStatement belongsTo = subModule.getSubStatement(YangBuiltinKeyword.BELONGSTO.getQName()).get(0);
                   String mainModuleName = belongsTo.getArgStr();
                   if (moduleSupportCapability.getModule().equals(mainModuleName)) {
                      match = true;
@@ -172,12 +158,10 @@ public class YangYinParser {
                unMatchedModules.add(module);
             }
          }
-         Iterator unMatchedModuleIt = unMatchedModules.iterator();
 
-         while (unMatchedModuleIt.hasNext()) {
-            module = (Module) unMatchedModuleIt.next();
-            schemaContext.removeModule(module.getModuleId());
-            schemaContext.addImportOnlyModule(module);
+         for (Module unMatchedModule : unMatchedModules) {
+            schemaContext.removeModule(unMatchedModule.getModuleId());
+            schemaContext.addImportOnlyModule(unMatchedModule);
          }
 
          YangSchema yangSchema = schemaContext.getYangSchema();

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YinParser.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YinParser.java
@@ -81,11 +81,11 @@ public class YinParser {
    }
 
    public List<YangElement> parse(Document document) throws YangParserException {
-      List<YangElement> elements = new ArrayList();
+      List<YangElement> elements = new ArrayList<>();
       Iterator<Node> nodes = document.nodeIterator();
 
       while(nodes.hasNext()) {
-         Node node = (Node)nodes.next();
+         Node node = nodes.next();
          if (node instanceof Comment) {
             elements.add(buildYangComment((Comment)node, this.fileName));
          } else if (node instanceof Element) {

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YinUnknownBlock.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/parser/YinUnknownBlock.java
@@ -31,14 +31,14 @@ class YinUnknownBlock extends YangUnknownBlock<Element> {
    }
 
    public YangUnknown build(YangContext context) {
-      String keyword = ((Element)this.getBlock()).getQualifiedName();
-      String namespace = ((Element)this.getBlock()).getNamespaceURI();
+      String keyword = this.getBlock().getQualifiedName();
+      String namespace = this.getBlock().getNamespaceURI();
       FName fName = new FName(keyword);
       List<Module> moduleList = context.getSchemaContext().getModule(URI.create(namespace));
       if (moduleList.isEmpty()) {
          throw new IllegalArgumentException("no module's namespace is " + namespace);
       } else {
-         Extension extension = ((Module)moduleList.get(0)).getExtension(fName.getLocalName());
+         Extension extension = moduleList.get(0).getExtension(fName.getLocalName());
          if (null == extension) {
             throw new IllegalArgumentException("can not find a extension named:" + fName.getLocalName());
          } else {
@@ -48,9 +48,9 @@ class YinUnknownBlock extends YangUnknownBlock<Element> {
             if (extension.getArgument() != null) {
                isYinElement = extension.getArgument().isYinElement();
                if (isYinElement) {
-                  argStr = ((Element)this.getBlock()).elementText(extension.getArgument().getArgStr());
+                  argStr = this.getBlock().elementText(extension.getArgument().getArgStr());
                } else {
-                  argStr = ((Element)this.getBlock()).attributeValue(extension.getArgument().getArgStr());
+                  argStr = this.getBlock().attributeValue(extension.getArgument().getArgStr());
                }
             }
 
@@ -59,17 +59,17 @@ class YinUnknownBlock extends YangUnknownBlock<Element> {
                try {
                   Constructor<? extends YangStatement> constructor = parserPolicy.getClazz().getConstructor(String.class);
                   yangUnknown = (YangUnknown)constructor.newInstance(argStr);
-                  yangUnknown.setElementPosition(new Position(this.fileName, new XPathLocation(((Element)this.getBlock()).getUniquePath())));
+                  yangUnknown.setElementPosition(new Position(this.fileName, new XPathLocation(this.getBlock().getUniquePath())));
                } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException var19) {
-                  throw new IllegalArgumentException((new Position(this.fileName, new XPathLocation(((Element)this.getBlock()).getUniquePath()))).toString() + " can not create instance for this statement.");
+                  throw new IllegalArgumentException((new Position(this.fileName, new XPathLocation(this.getBlock().getUniquePath()))) + " can not create instance for this statement.");
                }
             } else {
-               yangUnknown = YangStatementRegister.getInstance().getDefaultUnknownInstance(((Element)this.getBlock()).getQualifiedName(), argStr);
-               yangUnknown.setElementPosition(new Position(this.fileName, new XPathLocation(((Element)this.getBlock()).getUniquePath())));
+               yangUnknown = YangStatementRegister.getInstance().getDefaultUnknownInstance(this.getBlock().getQualifiedName(), argStr);
+               yangUnknown.setElementPosition(new Position(this.fileName, new XPathLocation(this.getBlock().getUniquePath())));
             }
 
             boolean hasChildren = false;
-            Element root = (Element)this.getBlock();
+            Element root = this.getBlock();
             if (isYinElement) {
                if (root.nodeCount() > 1) {
                   hasChildren = true;

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/writter/YangWriter.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/writter/YangWriter.java
@@ -9,7 +9,6 @@ import org.yangcentral.yangkit.model.api.stmt.Identifiable;
 import org.yangcentral.yangkit.model.api.stmt.YangBuiltinStatement;
 import org.yangcentral.yangkit.model.api.stmt.YangStatement;
 import org.yangcentral.yangkit.model.api.stmt.YangUnknown;
-import java.util.Iterator;
 
 public class YangWriter {
    private static String convert2DQValue(String value) {
@@ -64,9 +63,9 @@ public class YangWriter {
          int maxlineSize = columnSize - beginPos;
 
          if (-1 == lfPos) {
-            linebreakerPos = inlength < maxlineSize ? inlength : maxlineSize;
+            linebreakerPos = Math.min(inlength, maxlineSize);
          } else {
-            linebreakerPos = lfPos < maxlineSize ? lfPos : maxlineSize;
+            linebreakerPos = Math.min(lfPos, maxlineSize);
          }
 
          if (linebreakerPos == inlength) {
@@ -265,10 +264,7 @@ public class YangWriter {
                   nextIndentation = curIndentation + format.getIndentation();
                }
 
-               Iterator var18 = statement.getSubElements().iterator();
-
-               while(var18.hasNext()) {
-                  YangElement subElement = (YangElement)var18.next();
+               for (YangElement subElement : statement.getSubElements()) {
                   sb.append(toYangString(subElement, format, nextIndentation));
                }
 

--- a/yangkit-parser/src/main/java/org/yangcentral/yangkit/writter/YinWriter.java
+++ b/yangkit-parser/src/main/java/org/yangcentral/yangkit/writter/YinWriter.java
@@ -12,7 +12,6 @@ import org.yangcentral.yangkit.parser.YinParser;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
-import java.util.Iterator;
 import java.util.List;
 
 public class YinWriter {
@@ -57,10 +56,7 @@ public class YinWriter {
             }
          }
 
-         Iterator var9 = yangStatement.getSubElements().iterator();
-
-         while(var9.hasNext()) {
-            YangElement childElement = (YangElement)var9.next();
+         for (YangElement childElement : yangStatement.getSubElements()) {
             Node childNode = serialize(childElement);
             if (childNode != null) {
                element.add(childNode);
@@ -75,10 +71,8 @@ public class YinWriter {
 
    public static Document serialize(List<YangElement> elements) {
       Document document = DocumentHelper.createDocument();
-      Iterator var2 = elements.iterator();
 
-      while(var2.hasNext()) {
-         YangElement yangElement = (YangElement)var2.next();
+      for (YangElement yangElement : elements) {
          Node node = serialize(yangElement);
          if (node != null) {
             document.add(node);

--- a/yangkit-xpath-api/src/main/java/org/yangcentral/yangkit/xpath/YangContextSupport.java
+++ b/yangkit-xpath-api/src/main/java/org/yangcentral/yangkit/xpath/YangContextSupport.java
@@ -33,6 +33,6 @@ public class YangContextSupport extends ContextSupport {
 
    public static enum EvaluateType {
       NORMAL,
-      NEST;
+      NEST,
    }
 }

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/XPathUtil.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/XPathUtil.java
@@ -2,10 +2,8 @@ package org.yangcentral.yangkit.xpath.impl;
 
 import org.jaxen.expr.*;
 import org.yangcentral.yangkit.common.api.FName;
-import org.yangcentral.yangkit.common.api.Namespace;
 import org.yangcentral.yangkit.data.api.model.YangData;
 import org.yangcentral.yangkit.data.api.model.YangDataDocument;
-import org.yangcentral.yangkit.model.api.schema.ModuleId;
 import org.yangcentral.yangkit.model.api.schema.YangSchemaContext;
 import org.yangcentral.yangkit.model.api.stmt.*;
 import org.yangcentral.yangkit.model.api.stmt.Module;

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangFunctionContext.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangFunctionContext.java
@@ -36,17 +36,17 @@ public class YangFunctionContext extends XPathFunctionContext {
    }
 
    private void registerYang10Functions() {
-      this.registerFunction((String)null, "current", new CurrentFunction());
+      this.registerFunction(null, "current", new CurrentFunction());
    }
 
    private void registerYang11Functions() {
-      this.registerFunction((String)null, "current", new CurrentFunction());
-      this.registerFunction((String)null, "deref", new DeRefFunction());
-      this.registerFunction((String)null, "re-match", new ReMatchFunction());
-      this.registerFunction((String)null, "derived-from", new DerivedFromFunction());
-      this.registerFunction((String)null, "derived-from-or-self", new DerivedFromOrSelfFunction());
-      this.registerFunction((String)null, "enum-value", new EnumValueFunction());
-      this.registerFunction((String)null, "bit-is-set", new BitIsSetFunction());
+      this.registerFunction(null, "current", new CurrentFunction());
+      this.registerFunction(null, "deref", new DeRefFunction());
+      this.registerFunction(null, "re-match", new ReMatchFunction());
+      this.registerFunction(null, "derived-from", new DerivedFromFunction());
+      this.registerFunction(null, "derived-from-or-self", new DerivedFromOrSelfFunction());
+      this.registerFunction(null, "enum-value", new EnumValueFunction());
+      this.registerFunction(null, "bit-is-set", new BitIsSetFunction());
    }
 
    public Function getFunction(String namespaceURI, String prefix, String localName) throws UnresolvableException {

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangLocationPathImpl.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangLocationPathImpl.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import java.util.*;
 
 public abstract class YangLocationPathImpl implements YangLocationPath {
-   private List<Step> steps = new LinkedList();
+   private List<Step> steps = new LinkedList<>();
    private boolean isStrictPath = true;
 
    public void setStrictPath(boolean strictPath) {
@@ -35,16 +35,17 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
       this.steps.add(step);
    }
 
-   public List getSteps() {
+   public List<Step> getSteps() {
       return this.steps;
    }
 
    public String getText() {
       StringBuilder buf = new StringBuilder();
-      Iterator stepIter = this.getSteps().iterator();
+
+      Iterator<Step> stepIter = this.getSteps().iterator();
 
       while(stepIter.hasNext()) {
-         Step step = (Step)stepIter.next();
+         Step step = stepIter.next();
          if (step.getAxis() == 3) {
             buf.append("..");
          } else if (step.getAxis() == 11) {
@@ -62,11 +63,7 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
    }
 
    public Expr simplify() {
-      Iterator stepIter = this.getSteps().iterator();
-      Step eachStep = null;
-
-      while(stepIter.hasNext()) {
-         eachStep = (Step)stepIter.next();
+      for (Step eachStep : this.getSteps()) {
          eachStep.simplify();
       }
 
@@ -106,7 +103,7 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
    }
 
    public SchemaNode getTargetSchemaNode(YangXPathContext xPathContext) throws ModelException {
-      List steps = this.getSteps();
+      List<Step> steps = this.getSteps();
       Object current = xPathContext.getCurrentNode();
       if (this.isAbsolute()) {
          if (current instanceof Module) {
@@ -116,12 +113,11 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
          }
       }
 
-      Iterator iterator = steps.iterator();
+      Iterator<Step> iterator = steps.iterator();
 
       while(true) {
          while(iterator.hasNext()) {
-            Object o = iterator.next();
-            Step step = (Step)o;
+            Step step = iterator.next();
             if (step.getAxis() == Axis.PARENT) {
                if (current instanceof SchemaNodeContainer && ((SchemaNodeContainer)current).isSchemaTreeRoot()) {
                   throw new ModelException(Severity.WARNING, xPathContext.getDefineNode(), ErrorCode.INVALID_XPATH.getFieldName());
@@ -177,22 +173,22 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
    }
 
    public Object evaluate(Context context) throws JaxenException {
-      List nodeSet = context.getNodeSet();
-      List contextNodeSet = new ArrayList(nodeSet);
+      List<Step> nodeSet = context.getNodeSet();
+      List<Step> contextNodeSet = new ArrayList<>(nodeSet);
       YangContextSupport support = (YangContextSupport)context.getContextSupport();
       Context stepContext = new Context(support);
-      Iterator stepIter = this.getSteps().iterator();
+      Iterator<Step> stepIter = this.getSteps().iterator();
 
       while(stepIter.hasNext()) {
-         Step eachStep = (Step)stepIter.next();
-         stepContext.setNodeSet((List)contextNodeSet);
+         Step eachStep = stepIter.next();
+         stepContext.setNodeSet(contextNodeSet);
          contextNodeSet = eachStep.evaluate(stepContext);
          if (support.getEvaluateType() == YangContextSupport.EvaluateType.NEST) {
-            int size = ((List)contextNodeSet).size();
-            List<YangData> dummyNodes = new ArrayList();
+            int size = contextNodeSet.size();
+            List<YangData> dummyNodes = new ArrayList<>();
 
             for(int i = 0; i < size; ++i) {
-               Object node = ((List)contextNodeSet).get(i);
+               Object node = contextNodeSet.get(i);
                if (node instanceof YangData) {
                   YangData<?> yangData = (YangData)node;
                   boolean result = yangData.checkWhen();
@@ -207,16 +203,13 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
                }
             }
 
-            Iterator iterator = dummyNodes.iterator();
-
-            while(iterator.hasNext()) {
-               YangData dummyNode = (YangData)iterator.next();
-               ((List)contextNodeSet).remove(dummyNode);
+            for (YangData dummyNode : dummyNodes) {
+               contextNodeSet.remove(dummyNode);
             }
          }
 
          if (this.isReverseAxis(eachStep)) {
-            Collections.reverse((List)contextNodeSet);
+            Collections.reverse(contextNodeSet);
          }
       }
 
@@ -229,7 +222,8 @@ public abstract class YangLocationPathImpl implements YangLocationPath {
 
    public String toString() {
       StringBuilder buf = new StringBuilder();
-      Iterator stepIter = this.getSteps().iterator();
+
+      Iterator<Step> stepIter = this.getSteps().iterator();
 
       while(stepIter.hasNext()) {
          buf.append(stepIter.next().toString());

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathBaseVisitor.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathBaseVisitor.java
@@ -2,7 +2,6 @@ package org.yangcentral.yangkit.xpath.impl;
 
 import org.yangcentral.yangkit.common.api.Builder;
 import org.yangcentral.yangkit.common.api.BuilderFactory;
-import java.util.Iterator;
 import java.util.List;
 import org.jaxen.expr.AdditiveExpr;
 import org.jaxen.expr.BinaryExpr;
@@ -112,11 +111,9 @@ public abstract class YangXPathBaseVisitor<T, C, Context extends YangXPathVisito
       Builder<T> builder = this.builderFactory.getBuilder();
       builder.merge(this.visit(otherExpr, context));
       List predicates = expr.getPredicates();
-      Iterator var6 = predicates.iterator();
 
-      while(var6.hasNext()) {
-         Object o = var6.next();
-         Predicate predicate = (Predicate)o;
+      for (Object o : predicates) {
+         Predicate predicate = (Predicate) o;
          builder.merge(this.visit(predicate.getExpr(), context));
       }
 
@@ -126,11 +123,9 @@ public abstract class YangXPathBaseVisitor<T, C, Context extends YangXPathVisito
    public T visitFunctionCallExpr(FunctionCallExpr expr, C context) {
       Builder<T> builder = this.builderFactory.getBuilder();
       List parameters = expr.getParameters();
-      Iterator var5 = parameters.iterator();
 
-      while(var5.hasNext()) {
-         Object o = var5.next();
-         Expr para = (Expr)o;
+      for (Object o : parameters) {
+         Expr para = (Expr) o;
          builder.merge(this.visit(para, context));
       }
 

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathImpl.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathImpl.java
@@ -26,17 +26,16 @@ import org.jaxen.saxpath.XPathReader;
 import org.jaxen.saxpath.XPathSyntaxException;
 import org.jaxen.saxpath.helpers.XPathReaderFactory;
 import org.jaxen.util.SingletonList;
-import org.yangcentral.yangkit.model.api.stmt.XPathSupport;
 import org.yangcentral.yangkit.xpath.YangContextSupport;
 import org.yangcentral.yangkit.xpath.YangXPath;
 import org.yangcentral.yangkit.xpath.YangXPathVisitorContext;
 
 public class YangXPathImpl implements YangXPath {
-   private String yangVersion = "1";
+   private final String yangVersion = "1";
    private final String exprText;
    private final XPathExpr xpath;
    private YangContextSupport support;
-   private Navigator navigator;
+   private final Navigator navigator;
    private YangXPathContext xPathContext;
 
 
@@ -97,7 +96,7 @@ public class YangXPathImpl implements YangXPath {
    public boolean booleanValueOf(Object o) throws JaxenException {
       Context context = this.getContext(o);
       List result = this.selectNodesForContext(context);
-      return result == null ? false : BooleanFunction.evaluate(result, context.getNavigator());
+      return result != null && BooleanFunction.evaluate(result, context.getNavigator());
    }
 
    public Number numberValueOf(Object o) throws JaxenException {
@@ -206,11 +205,11 @@ public class YangXPathImpl implements YangXPath {
          Iterator<Map.Entry<String, ModuleId>> prefixCache = this.xPathContext.getYangContext().getCurModule().getPrefixes().entrySet().iterator();
 
          while(prefixCache.hasNext()) {
-            Map.Entry<String, ModuleId> entry = (Map.Entry)prefixCache.next();
-            ModuleId moduleId = (ModuleId)entry.getValue();
+            Map.Entry<String, ModuleId> entry = prefixCache.next();
+            ModuleId moduleId = entry.getValue();
             Optional<Module> module = this.xPathContext.getYangContext().getSchemaContext().getModule(moduleId);
             if (module.isPresent()) {
-               namespaceContext.addNamespace((String)entry.getKey(), ((Module)module.get()).getMainModule().getNamespace().getUri().toString());
+               namespaceContext.addNamespace(entry.getKey(), module.get().getMainModule().getNamespace().getUri().toString());
             }
          }
 

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathPrefixVisitor.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathPrefixVisitor.java
@@ -31,9 +31,8 @@ public class YangXPathPrefixVisitor implements YangXPathVisitor<List<String>, XP
 
     @Override
     public List<String> visitBinaryExpr(BinaryExpr binaryExpr, XPathSupport xPathSupport) {
-        List<String> transformerResults = new ArrayList<>();
         List<String> left = visit(binaryExpr.getLHS(),statement);
-        transformerResults.addAll(left);
+        List<String> transformerResults = new ArrayList<>(left);
         List<String> right = visit(binaryExpr.getRHS(),statement);
         transformerResults.addAll(right);
         return transformerResults;
@@ -46,9 +45,8 @@ public class YangXPathPrefixVisitor implements YangXPathVisitor<List<String>, XP
 
     @Override
     public List<String> visitFilterExpr(FilterExpr filterExpr, XPathSupport xPathSupport) {
-        List<String> transformerResults = new ArrayList<>();
         Expr expr = filterExpr.getExpr();
-        transformerResults.addAll(visit(expr,statement));
+        List<String> transformerResults = new ArrayList<>(visit(expr, statement));
         List predicates = filterExpr.getPredicates();
         if(predicates != null && predicates.size()>0){
             for(Object o:predicates){

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathRoot.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathRoot.java
@@ -13,16 +13,14 @@ import java.util.Iterator;
 import java.util.List;
 
 class YangXPathRoot implements SchemaNodeContainer {
-   private List<SchemaNode> schemaNodes = new ArrayList();
-   private Namespace namespace;
+   private final List<SchemaNode> schemaNodes = new ArrayList<>();
+   private final Namespace namespace;
 
    public YangXPathRoot(Module module) {
       this.namespace = new Namespace(module.getMainModule().getNamespace().getUri(), module.getMainModule().getPrefix().getArgStr());
       List<SchemaNode> contextSchemaNodes = module.getContext().getSchemaContext().getSchemaNodeChildren();
-      Iterator iterator = contextSchemaNodes.iterator();
 
-      while(iterator.hasNext()) {
-         SchemaNode contextSchemaNode = (SchemaNode)iterator.next();
+      for (SchemaNode contextSchemaNode : contextSchemaNodes) {
          if (contextSchemaNode instanceof DataDefinition) {
             this.addSchemaNodeChild(contextSchemaNode);
          }
@@ -33,34 +31,26 @@ class YangXPathRoot implements SchemaNodeContainer {
    public YangXPathRoot(SchemaNode schemaNode) {
       this.namespace = schemaNode.getContext().getNamespace();
       List<SchemaNode> contextSchemaNodes = schemaNode.getContext().getSchemaContext().getSchemaNodeChildren();
-      Iterator iterator = contextSchemaNodes.iterator();
 
-      while(iterator.hasNext()) {
-         SchemaNode contextSchemaNode = (SchemaNode)iterator.next();
+      for (SchemaNode contextSchemaNode : contextSchemaNodes) {
          if (contextSchemaNode instanceof DataDefinition) {
             this.addSchemaNodeChild(contextSchemaNode);
          }
       }
 
-      SchemaNode notificationChild;
-      List notificationChildren;
-      Iterator it;
+      List<SchemaNode> notificationChildren;
       if (schemaNode instanceof Rpc) {
          notificationChildren = ((Rpc)schemaNode).getSchemaNodeChildren();
-         it = notificationChildren.iterator();
 
-         while(it.hasNext()) {
-            notificationChild = (SchemaNode)it.next();
+         for (SchemaNode notificationChild : notificationChildren) {
             this.addSchemaNodeChild(notificationChild);
          }
       }
 
       if (schemaNode instanceof Notification && schemaNode.getParentSchemaNode() instanceof Module) {
          notificationChildren = ((Notification)schemaNode).getSchemaNodeChildren();
-         it = notificationChildren.iterator();
 
-         while(it.hasNext()) {
-            notificationChild = (SchemaNode)it.next();
+         for (SchemaNode notificationChild : notificationChildren) {
             this.addSchemaNodeChild(notificationChild);
          }
       }
@@ -78,10 +68,8 @@ class YangXPathRoot implements SchemaNodeContainer {
 
    public ValidatorResult addSchemaNodeChildren(List<SchemaNode> schemaNodes) {
       ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-      Iterator iterator = this.schemaNodes.iterator();
 
-      while(iterator.hasNext()) {
-         SchemaNode node = (SchemaNode)iterator.next();
+      for (SchemaNode node : this.schemaNodes) {
          ValidatorResult result = this.addSchemaNodeChild(node);
          validatorResultBuilder.merge(result);
       }
@@ -91,12 +79,10 @@ class YangXPathRoot implements SchemaNodeContainer {
 
    public SchemaNode getSchemaNodeChild(QName identifier) {
       try {
-         Iterator iterator = this.schemaNodes.iterator();
 
-         while(iterator.hasNext()) {
-            SchemaNode schemaNode = (SchemaNode)iterator.next();
+         for (SchemaNode schemaNode : this.schemaNodes) {
             if (schemaNode instanceof VirtualSchemaNode) {
-               VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode)schemaNode;
+               VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode) schemaNode;
                SchemaNode node = virtualSchemaNode.getSchemaNodeChild(identifier);
                if (node != null) {
                   return node;
@@ -113,7 +99,7 @@ class YangXPathRoot implements SchemaNodeContainer {
    }
 
    public DataNode getDataNodeChild(QName identifier) {
-      Iterator iterator = this.schemaNodes.iterator();
+      Iterator<SchemaNode> iterator = this.schemaNodes.iterator();
 
       SchemaNode schemaNode;
       label35:
@@ -124,7 +110,7 @@ class YangXPathRoot implements SchemaNodeContainer {
                return null;
             }
 
-            schemaNode = (SchemaNode)iterator.next();
+            schemaNode = iterator.next();
             if (!(schemaNode instanceof VirtualSchemaNode) && !(schemaNode instanceof Choice) && !(schemaNode instanceof Case) && !(schemaNode instanceof Input) && !(schemaNode instanceof Output)) {
                continue label35;
             }
@@ -144,12 +130,12 @@ class YangXPathRoot implements SchemaNodeContainer {
    }
 
    public List<DataNode> getDataNodeChildren() {
-      List<DataNode> dataNodeChildren = new ArrayList();
-      Iterator iterator = this.schemaNodes.iterator();
+      List<DataNode> dataNodeChildren = new ArrayList<>();
+      Iterator<SchemaNode> iterator = this.schemaNodes.iterator();
 
       while(true) {
          while(iterator.hasNext()) {
-            SchemaNode schemaNode = (SchemaNode)iterator.next();
+            SchemaNode schemaNode = iterator.next();
             if (!(schemaNode instanceof VirtualSchemaNode) && !(schemaNode instanceof Choice) && !(schemaNode instanceof Case) && !(schemaNode instanceof Input) && !(schemaNode instanceof Output)) {
                if (schemaNode instanceof DataNode) {
                   dataNodeChildren.add((DataNode)schemaNode);
@@ -190,12 +176,10 @@ class YangXPathRoot implements SchemaNodeContainer {
 
    public void removeSchemaNodeChild(QName identifier) {
       SchemaNode target = null;
-      Iterator var3 = this.schemaNodes.iterator();
 
-      while(var3.hasNext()) {
-         SchemaNode schemaNode = (SchemaNode)var3.next();
+      for (SchemaNode schemaNode : this.schemaNodes) {
          if (schemaNode instanceof VirtualSchemaNode) {
-            VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode)schemaNode;
+            VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode) schemaNode;
             virtualSchemaNode.removeSchemaNodeChild(identifier);
          } else if (schemaNode.getIdentifier().equals(identifier)) {
             target = schemaNode;
@@ -212,12 +196,10 @@ class YangXPathRoot implements SchemaNodeContainer {
       if (this.schemaNodes.contains(schemaNode)) {
          this.schemaNodes.remove(schemaNode);
       } else {
-         Iterator var2 = this.schemaNodes.iterator();
 
-         while(var2.hasNext()) {
-            SchemaNode node = (SchemaNode)var2.next();
+         for (SchemaNode node : this.schemaNodes) {
             if (node instanceof VirtualSchemaNode) {
-               VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode)node;
+               VirtualSchemaNode virtualSchemaNode = (VirtualSchemaNode) node;
                virtualSchemaNode.removeSchemaNodeChild(schemaNode);
             }
          }

--- a/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathValidator.java
+++ b/yangkit-xpath-impl/src/main/java/org/yangcentral/yangkit/xpath/impl/YangXPathValidator.java
@@ -1,7 +1,6 @@
 package org.yangcentral.yangkit.xpath.impl;
 
 import java.net.URI;
-import java.util.Iterator;
 import java.util.List;
 
 import org.jaxen.expr.AdditiveExpr;
@@ -60,8 +59,8 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
       ValidatorRecordBuilder validatorRecordBuilder;
       if (!(context instanceof YangList)) {
          validatorRecordBuilder = new ValidatorRecordBuilder();
-         validatorRecordBuilder.setBadElement(((YangXPathContext)this.getContext()).getDefineNode());
-         validatorRecordBuilder.setErrorPath(((YangXPathContext)this.getContext()).getDefineNode().getElementPosition());
+         validatorRecordBuilder.setBadElement(this.getContext().getDefineNode());
+         validatorRecordBuilder.setErrorPath(this.getContext().getDefineNode().getElementPosition());
          exprLHS = null;
          String nodeName;
          if (context instanceof SchemaNodeContainer && ((SchemaNodeContainer)context).isSchemaTreeRoot()) {
@@ -74,33 +73,33 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
          ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
          validatorResultBuilder.addRecord(validatorRecordBuilder.build());
          builder.merge(validatorResultBuilder.build());
-         return (ValidatorResult)builder.build();
+         return builder.build();
       } else if (!(predicate.getExpr() instanceof EqualityExpr)) {
          validatorRecordBuilder = new ValidatorRecordBuilder();
-         validatorRecordBuilder.setBadElement(((YangXPathContext)this.getContext()).getDefineNode());
-         validatorRecordBuilder.setErrorPath(((YangXPathContext)this.getContext()).getDefineNode().getElementPosition());
+         validatorRecordBuilder.setBadElement(this.getContext().getDefineNode());
+         validatorRecordBuilder.setErrorPath(this.getContext().getDefineNode().getElementPosition());
          validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.INVALID_XPATH_LEAFREF_PREDICATE_MUST_EQUALITY.toString(new String[]{"xpath=" + this.getYangXPath().toString()})));
          ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
          validatorResultBuilder.addRecord(validatorRecordBuilder.build());
          builder.merge(validatorResultBuilder.build());
-         return (ValidatorResult)builder.build();
+         return builder.build();
       } else {
          EqualityExpr equalityExpr = (EqualityExpr)predicate.getExpr();
          exprLHS = equalityExpr.getLHS();
          if (!(exprLHS instanceof LocationPath)) {
             validatorRecordBuilder = new ValidatorRecordBuilder();
-            validatorRecordBuilder.setBadElement(((YangXPathContext)this.getContext()).getDefineNode());
-            validatorRecordBuilder.setErrorPath(((YangXPathContext)this.getContext()).getDefineNode().getElementPosition());
+            validatorRecordBuilder.setBadElement(this.getContext().getDefineNode());
+            validatorRecordBuilder.setErrorPath(this.getContext().getDefineNode().getElementPosition());
             validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.INVALID_XPATH_LEAFREF_PREDICATE_MUST_KEY.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + exprLHS.getText()})));
             ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
             validatorResultBuilder.addRecord(validatorRecordBuilder.build());
             builder.merge(validatorResultBuilder.build());
-            return (ValidatorResult)builder.build();
+            return builder.build();
          } else {
             YangLocationPathImpl keyLocation = (YangLocationPathImpl)exprLHS;
 
             try {
-               YangXPathContext keyXPathContext = ((YangXPathContext)this.getContext()).newContext();
+               YangXPathContext keyXPathContext = this.getContext().newContext();
                keyXPathContext.setCurrentNode(context);
                SchemaNode keyNode = keyLocation.getTargetSchemaNode(keyXPathContext);
                if (((YangList)context).getKey().getKeyNode(keyNode.getIdentifier()) == null) {
@@ -121,10 +120,10 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
 //               ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
 //               validatorResultBuilder.addRecord(validatorRecordBuilder.build());
 //               builder.merge(validatorResultBuilder.build());
-               return (ValidatorResult)builder.build();
+               return builder.build();
             }
 
-            return (ValidatorResult)builder.build();
+            return builder.build();
          }
       }
    }
@@ -151,12 +150,12 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
             if (prefix != null && prefix.length() > 0) {
                Module module = ModelUtil.findModuleByPrefix(this.getContext().getYangContext(), prefix);
                if (null == module) {
-                  throw new ModelException(Severity.WARNING, ((YangXPathContext)this.getContext()).getDefineNode(), ErrorCode.INVALID_PREFIX.toString(new String[]{"name=" + prefix}));
+                  throw new ModelException(Severity.WARNING, this.getContext().getDefineNode(), ErrorCode.INVALID_PREFIX.toString(new String[]{"name=" + prefix}));
                }
 
                namespace = module.getMainModule().getNamespace().getUri();
             } else {
-               Object contextNode = ((YangXPathContext)this.getContext()).getContextNode();
+               Object contextNode = this.getContext().getContextNode();
                if (contextNode instanceof Module) {
                   Module curModule = (Module)contextNode;
                   namespace = curModule.getMainModule().getNamespace().getUri();
@@ -169,21 +168,21 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
 
             QName childQName = new QName(namespace, prefix, localName);
             if (!(currentNode instanceof SchemaNodeContainer)) {
-               throw new ModelException(Severity.WARNING, ((YangXPathContext)this.getContext()).getDefineNode(), ErrorCode.INVALID_XPATH_TERMIANL_HAS_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + ((SchemaNode)currentNode).getIdentifier().getQualifiedName(), "keyword=" + ((SchemaNode)currentNode).getYangKeyword().getLocalName()}));
+               throw new ModelException(Severity.WARNING, this.getContext().getDefineNode(), ErrorCode.INVALID_XPATH_TERMIANL_HAS_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + ((SchemaNode)currentNode).getIdentifier().getQualifiedName(), "keyword=" + ((SchemaNode)currentNode).getYangKeyword().getLocalName()}));
             }
 
             SchemaNodeContainer parent = (SchemaNodeContainer)currentNode;
             SchemaNode child = YangLocationPathImpl.getXPathSchemaChild(parent, childQName);
             if (child == null) {
-               throw new ModelException(Severity.WARNING, ((YangXPathContext)this.getContext()).getDefineNode(), ErrorCode.INVALID_XPATH_UNRECOGNIZED_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + (!((SchemaNodeContainer)currentNode).isSchemaTreeRoot() ? ((SchemaNode)currentNode).getIdentifier().getQualifiedName() : "/"), "child=" + childQName.getQualifiedName()}));
+               throw new ModelException(Severity.WARNING, this.getContext().getDefineNode(), ErrorCode.INVALID_XPATH_UNRECOGNIZED_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + (!((SchemaNodeContainer)currentNode).isSchemaTreeRoot() ? ((SchemaNode)currentNode).getIdentifier().getQualifiedName() : "/"), "child=" + childQName.getQualifiedName()}));
             }
 
-            if (((YangXPathContext)this.getContext()).getDefineNode().isActive() && !child.isActive()) {
-               throw new ModelException(Severity.WARNING, ((YangXPathContext)this.getContext()).getDefineNode(), ErrorCode.INVALID_XPATH_INACTIVE_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + (!((SchemaNodeContainer)currentNode).isSchemaTreeRoot() ? ((SchemaNode)currentNode).getIdentifier().getQualifiedName() : "/"), "child=" + childQName.getQualifiedName()}));
+            if (this.getContext().getDefineNode().isActive() && !child.isActive()) {
+               throw new ModelException(Severity.WARNING, this.getContext().getDefineNode(), ErrorCode.INVALID_XPATH_INACTIVE_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + (!((SchemaNodeContainer)currentNode).isSchemaTreeRoot() ? ((SchemaNode)currentNode).getIdentifier().getQualifiedName() : "/"), "child=" + childQName.getQualifiedName()}));
             }
 
-            if (((YangXPathContext)this.getContext()).getContextNode() instanceof SchemaNode && ((SchemaNode)((YangXPathContext)this.getContext()).getContextNode()).isConfig() && !child.isConfig()) {
-               throw new ModelException(Severity.WARNING, ((YangXPathContext)this.getContext()).getDefineNode(), ErrorCode.INVALID_XPATH_UNCMPATIBLE_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + (!((SchemaNodeContainer)currentNode).isSchemaTreeRoot() ? ((SchemaNode)currentNode).getIdentifier().getQualifiedName() : "/"), "context=" + ((SchemaNode)((YangXPathContext)this.getContext()).getContextNode()).getIdentifier().getQualifiedName()}));
+            if (this.getContext().getContextNode() instanceof SchemaNode && ((SchemaNode) this.getContext().getContextNode()).isConfig() && !child.isConfig()) {
+               throw new ModelException(Severity.WARNING, this.getContext().getDefineNode(), ErrorCode.INVALID_XPATH_UNCMPATIBLE_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "nodename=" + (!((SchemaNodeContainer)currentNode).isSchemaTreeRoot() ? ((SchemaNode)currentNode).getIdentifier().getQualifiedName() : "/"), "context=" + ((SchemaNode) this.getContext().getContextNode()).getIdentifier().getQualifiedName()}));
             }
 
             if (child instanceof WhenSupport && this.validateType == VALIDATE_TYPE_WHEN) {
@@ -205,25 +204,23 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
       if (step instanceof Predicated) {
          List predicates = step.getPredicates();
          if (predicates.size() > 0) {
-            Iterator predicateIt = predicates.iterator();
 
-            while(predicateIt.hasNext()) {
-               Object o1 = predicateIt.next();
-               Predicate predicate = (Predicate)o1;
+            for (Object o1 : predicates) {
+               Predicate predicate = (Predicate) o1;
                ValidatorResult predicateResult;
                if (this.validateType == VALIDATE_TYPE_LEAFREF) {
                   predicateResult = this.checkPredicateForLeafref(predicate, currentNode);
                   if (!predicateResult.isOk()) {
-                     throw new ModelException(Severity.WARNING, ((YangXPathContext)this.getContext()).getDefineNode(), predicateResult.toString());
+                     throw new ModelException(Severity.WARNING, this.getContext().getDefineNode(), predicateResult.toString());
                   }
                }
-               predicateResult = (ValidatorResult)this.visit(predicate.getExpr(), currentNode);
+               predicateResult = this.visit(predicate.getExpr(), currentNode);
                if (!predicateResult.isOk()) {
-                  throw new ModelException(Severity.WARNING, ((YangXPathContext)this.getContext()).getDefineNode(), predicateResult.toString());
+                  throw new ModelException(Severity.WARNING, this.getContext().getDefineNode(), predicateResult.toString());
                }
-               if(predicate.getExpr() instanceof FunctionCallExpr && ((FunctionCallExpr) predicate.getExpr()).getFunctionName().equals("current")){
+               if (predicate.getExpr() instanceof FunctionCallExpr && ((FunctionCallExpr) predicate.getExpr()).getFunctionName().equals("current")) {
                   throw new ModelException(Severity.WARNING, this.getContext().getDefineNode(),
-                          ErrorCode.PREDICATES_MUST_EXPRESSION.toString(new String[]{"xpath=" + this.getYangXPath().toString()})
+                      ErrorCode.PREDICATES_MUST_EXPRESSION.toString(new String[]{"xpath=" + this.getYangXPath().toString()})
                   );
                }
             }
@@ -245,17 +242,15 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
       }
 
       List steps = expr.getSteps();
-      Iterator iterator = steps.iterator();
 
-      while(iterator.hasNext()) {
-         Object o = iterator.next();
-         Step step = (Step)o;
+      for (Object o : steps) {
+         Step step = (Step) o;
 
          try {
             currentNode = this.visitStep(step, context, currentNode);
             if (currentNode instanceof YangList) {
                YangList listNode = (YangList) currentNode;
-               if(listNode.getKey() != null){
+               if (listNode.getKey() != null) {
                   List keys = listNode.getKey().getkeyNodes();
                   List predicts = step.getPredicates();
                   if (keys.size() > predicts.size()) {
@@ -267,7 +262,7 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
          } catch (ModelException e) {
             ValidatorResultBuilder stepValidatorResultBuilder = new ValidatorResultBuilder();
             stepValidatorResultBuilder.addRecord(ModelUtil.reportError(e.getElement(),
-                    e.getSeverity(), ErrorTag.BAD_ELEMENT,e.getDescription()));
+                e.getSeverity(), ErrorTag.BAD_ELEMENT, e.getDescription()));
             builder.merge(stepValidatorResultBuilder.build());
             return builder.build();
          }
@@ -277,15 +272,15 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
               && (currentNode == this.getContext().getDefineNode()
               || ((SchemaNode)currentNode).isAncestorNode(this.getContext().getDefineNode()))) {
          ValidatorRecordBuilder<Position, YangStatement> validatorRecordBuilder = new ValidatorRecordBuilder();
-         validatorRecordBuilder.setBadElement(((YangXPathContext)this.getContext()).getDefineNode());
-         validatorRecordBuilder.setErrorPath(((YangXPathContext)this.getContext()).getDefineNode().getElementPosition());
+         validatorRecordBuilder.setBadElement(this.getContext().getDefineNode());
+         validatorRecordBuilder.setErrorPath(this.getContext().getDefineNode().getElementPosition());
          validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.INVALID_XPATH_WHEN_ACCESS_CHILD.toString(new String[]{"xpath=" + this.getYangXPath().toString()})));
          ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
          validatorResultBuilder.addRecord(validatorRecordBuilder.build());
          builder.merge(validatorResultBuilder.build());
       }
 
-      return (ValidatorResult)builder.build();
+      return builder.build();
    }
 
    public ValidatorResult visitBinaryExpr(BinaryExpr expr, Object context) {
@@ -296,9 +291,9 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
          if (expr instanceof AdditiveExpr || expr instanceof EqualityExpr || expr instanceof MultiplicativeExpr || expr instanceof RelationalExpr) {
             if (expr.getLHS() instanceof LocationPath && ((LocationPath) expr.getLHS()).isAbsolute() && !((YangLocationPathImpl) expr.getLHS()).isStrictPath()) {
                ValidatorRecordBuilder<Position, YangStatement> validatorRecordBuilder = new ValidatorRecordBuilder();
-               validatorRecordBuilder.setBadElement(((YangXPathContext) this.getContext()).getDefineNode());
+               validatorRecordBuilder.setBadElement(this.getContext().getDefineNode());
                validatorRecordBuilder.setSeverity(ErrorCode.MISSING_PREDICATES.getSeverity());
-               validatorRecordBuilder.setErrorPath(((YangXPathContext) this.getContext()).getDefineNode().getElementPosition());
+               validatorRecordBuilder.setErrorPath(this.getContext().getDefineNode().getElementPosition());
                validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.MISSING_PREDICATES.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "listNode="})));
                ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
                validatorResultBuilder.addRecord(validatorRecordBuilder.build());
@@ -306,9 +301,9 @@ public class YangXPathValidator extends YangXPathBaseVisitor<ValidatorResult, Ob
             }
             if (expr.getRHS() instanceof LocationPath && ((LocationPath) expr.getRHS()).isAbsolute() && !((YangLocationPathImpl) expr.getRHS()).isStrictPath()) {
                ValidatorRecordBuilder<Position, YangStatement> validatorRecordBuilder = new ValidatorRecordBuilder();
-               validatorRecordBuilder.setBadElement(((YangXPathContext) this.getContext()).getDefineNode());
+               validatorRecordBuilder.setBadElement(this.getContext().getDefineNode());
                validatorRecordBuilder.setSeverity(ErrorCode.MISSING_PREDICATES.getSeverity());
-               validatorRecordBuilder.setErrorPath(((YangXPathContext) this.getContext()).getDefineNode().getElementPosition());
+               validatorRecordBuilder.setErrorPath(this.getContext().getDefineNode().getElementPosition());
                validatorRecordBuilder.setErrorMessage(new ErrorMessage(ErrorCode.MISSING_PREDICATES.toString(new String[]{"xpath=" + this.getYangXPath().toString(), "listNode="})));
                ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
                validatorResultBuilder.addRecord(validatorRecordBuilder.build());


### PR DESCRIPTION
- Eliminate lots of the raw generics usage to allow the compiler to better catch type errors are compile time
- Reduce the usage of the same iterator variable for multiple loop: that helps to make the code more readable
- Use for loops instead of iterators for more concise error free code
