### PR TITLE
fix: add missing simple and envelope-json convention YAML resources

### DIFF
--- a/yangkit-data-proto-codec/src/main/resources/convention/envelope-json-convention.yaml
+++ b/yangkit-data-proto-codec/src/main/resources/convention/envelope-json-convention.yaml
@@ -1,0 +1,8 @@
+convention:
+  name: "envelope"
+  description: "Envelope YANG to Protobuf mapping with JSON inner format"
+  encoding-mode: "envelope"
+envelope:
+  field-name: "data"
+  field-type: "bytes"
+  inner-format: "json"

--- a/yangkit-data-proto-codec/src/main/resources/convention/simple-convention.yaml
+++ b/yangkit-data-proto-codec/src/main/resources/convention/simple-convention.yaml
@@ -1,0 +1,8 @@
+convention:
+  name: "simple"
+  description: "Simple YANG to Protobuf mapping with primitive types and sequential field numbers"
+  encoding-mode: "structured"
+field-numbering: "sequential"
+scalar-wrapping: "none"
+bits-as: "string"
+union-as: "string"


### PR DESCRIPTION
## Summary

- `YangProtoConventionTest` 中两个测试因找不到 classpath 资源文件而失败
- 新增 `simple-convention.yaml`：顺序字段编号、原始类型、无 wrapper 的结构化约定
- 新增 `envelope-json-convention.yaml`：envelope 模式、JSON 内部格式的约定

## Test plan

- [x] `YangProtoConventionTest#loadBuiltinClasspathYaml_simple` 本地验证通过
- [x] `YangProtoConventionTest#loadBuiltinClasspathYaml_envelope` 本地验证通过
- [x] `yangkit-data-proto-codec` 模块完整测试套件通过

https://claude.ai/code/session_019NY8Mv6p6rb8HSB9pJKugn

---
_Generated by [Claude Code](https://claude.ai/code/session_019NY8Mv6p6rb8HSB9pJKugn)_